### PR TITLE
ci: bump workflow node-version 18 → 22 for Astro 6

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
       - name: Install dependencies
         run: npm ci --omit=dev


### PR DESCRIPTION
## Summary

Fix deploy failure from #70 (astro 5→6 upgrade wave).

Astro 6 requires Node.js >= 22.12.0; the workflows still pinned Node 18. Result: the deploy run for #70 failed at build step with:

> Node.js v18.20.8 is not supported by Astro!
> Please upgrade Node.js to a supported version: ">=22.12.0"

Bumps both workflows to Node 22:

- `.github/workflows/static.yml` (production GitHub Pages deploy)
- `.github/workflows/preview-deploy.yml` (Surge.sh branch previews)

## Impact

Production site is currently still up on the previous successful deploy (glob-13). This PR unblocks the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)