### PR TITLE
docs: correctness fixes from the 2026-04-22 review

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -31,8 +31,13 @@ export default defineConfig({
 			target: 'es2022', // Modern browsers for better tree-shaking
 			rollupOptions: {
 				treeshake: {
-					preset: 'recommended',
-					moduleSideEffects: false
+					preset: 'recommended'
+					// Do NOT set moduleSideEffects: false here. It strips
+					// CSS-only side-effect imports (e.g. Starlight's
+					// `import '../style/anchor-links.css'` in Page.astro
+					// via virtual:starlight/optional-css), producing
+					// broken rendering for heading anchor links and
+					// other styled Starlight features.
 				}
 			},
 			// Optimize CSS delivery

--- a/docs/superpowers/reviews/2026-04-22-correctness/README.md
+++ b/docs/superpowers/reviews/2026-04-22-correctness/README.md
@@ -74,6 +74,17 @@ Site-wide sweeps (see [`cross-cutting.md`](cross-cutting.md) §1–4) are the mo
 
 See [`cross-cutting.md`](cross-cutting.md) — scope contamination, endpoint path drift, `cyoda serve` phantom, `CYODA_STORAGE_BACKEND` typo, terminology drift, coverage gaps, clarity-suggestion synthesis.
 
+## Remediation status
+
+As of the `docs/correctness-fixes-2026-04-22` PR (pending merge to `feature/cyoda-go-init`):
+
+- **Fix-now findings actioned:** 20 / 20. Four site-wide sweeps (`CYODA_STORAGE_BACKEND` typo · `cyoda serve` phantom · `/api/models/...` endpoint drift · Trino "upcoming" banner) plus per-page residuals.
+- **Clarity suggestions actioned:** 36 / 36. Plus a follow-on correction (transition endpoint is `PUT`, not `POST`) that was caught during the endpoint-sweep implementation.
+- **Reframe post-#80:** 5 enumerated; deferred to the post-#80 reframe PR (cyoda-docs #69).
+- **Delete post-#80:** 1 enumerated (`concepts/workflows-and-events.md` time/message trigger paragraphs); deferred.
+
+Per-page review files under `pages/` are historical records of what the review found — they do **not** get updated to reflect applied fixes. The authoritative "is it fixed?" answer lives in the commits on the correctness-fixes branch and in the current content of `src/content/docs/`.
+
 ## Next steps
 
 1. **Fix-now remediation PR** — cut a branch off `feature/cyoda-go-init`, action every **Fix now** finding (20) and every accepted clarity suggestion (36). Site-wide sweeps first (single grep-and-replace across pages), then per-page fixes for content that doesn't fit a sweep. Review, merge.

--- a/src/components/VendoredBanner.astro
+++ b/src/components/VendoredBanner.astro
@@ -2,7 +2,7 @@
 // src/components/VendoredBanner.astro — banner on pages sourced from cyoda-go
 interface Props {
   source?: { repo?: string; path?: string; vendored_at?: string };
-  stability?: 'stable' | 'evolving' | 'awaiting-upstream';
+  stability?: 'stable' | 'evolving' | 'awaiting-upstream' | 'upcoming';
   issue?: string; // optional GitHub issue URL for awaiting-upstream
 }
 const { source, stability = 'stable', issue } = Astro.props;
@@ -19,6 +19,9 @@ const showBanner = stability !== 'stable' || source;
     )}
     {stability === 'evolving' && (
       <><strong>Evolving.</strong> This page may change rapidly with cyoda-go releases.</>
+    )}
+    {stability === 'upcoming' && (
+      <><strong>Upcoming.</strong> This describes a feature on the roadmap; it is not yet available in cyoda-go at this release. Names and shapes may change before release.</>
     )}
     {stability === 'stable' && source && (
       <>
@@ -42,5 +45,9 @@ const showBanner = stability !== 'stable' || source;
   .vendored-banner[data-stability='awaiting-upstream'] {
     border-left-color: hsl(var(--cyoda-purple));
     background: hsl(var(--cyoda-purple) / 0.08);
+  }
+  .vendored-banner[data-stability='upcoming'] {
+    border-left-color: hsl(var(--cyoda-blue, 210 80% 55%));
+    background: hsl(var(--cyoda-blue, 210 80% 55%) / 0.08);
   }
 </style>

--- a/src/content/docs/build/analytics-with-sql.md
+++ b/src/content/docs/build/analytics-with-sql.md
@@ -5,6 +5,10 @@ sidebar:
   order: 45
 ---
 
+:::caution[Upcoming]
+Trino SQL is on the roadmap and not yet available in cyoda-go at this release. This page documents the planned surface; names and shapes may change before release.
+:::
+
 Cyoda projects every entity model into a set of virtual SQL tables and
 exposes them through a Trino connector. Use this surface for cross-entity
 analytics: joins across entity types, aggregates, reporting, time-series,

--- a/src/content/docs/build/client-compute-nodes.md
+++ b/src/content/docs/build/client-compute-nodes.md
@@ -287,6 +287,8 @@ You may also send **client-initiated keep-alive** messages to confirm your own l
 | Max idle interval | 3,000 ms | How long before a member is marked as not alive |
 | Keep-alive check timeout | 1,000 ms | How long the server waits for a probe response |
 
+A member is marked not alive when a probe times out (keep-alive check timeout, default 1,000 ms) **and** the max idle interval (default 3,000 ms) has been exceeded since the last successful probe response. Both conditions must hold — a single slow probe within the idle window does not mark the member dead.
+
 **If your member is marked as not alive, the platform will not route requests to it.** The member remains registered but idle. Responding to a subsequent keep-alive probe restores the alive status.
 
 > ⚠️ **Critical**: Failing to respond to keep-alive probes will cause your member to be marked as dead. Ensure your keep-alive response handler is fast and non-blocking.
@@ -492,6 +494,8 @@ if (authClaimsJson != null) {
     List<String> roles = (List<String>) claims.get("roles");  // may be null for plain IUser
 }
 ```
+
+The exact accessor depends on your gRPC tooling — in Go, use the generated message's `GetAttributes()` method; in Python, dict-like indexing on `.attributes`. See your language's generated proto bindings.
 
 ## 8.4 Example Claims JSON
 

--- a/src/content/docs/build/searching-entities.md
+++ b/src/content/docs/build/searching-entities.md
@@ -124,8 +124,11 @@ against each release, see
 ## Historical reads with `pointInTime`
 
 Every search accepts a `pointInTime` parameter to run against the world
-as it existed at a given timestamp. The result is the set of entities
-that would have matched, using the revision active at that time.
+as it existed at a given timestamp. Each entity maintains a history of
+revisions; point-in-time queries return results using the entity state
+that was current at the specified timestamp. The result is the set of
+entities that would have matched, using the revision active at that
+time.
 
 ```bash
 curl -X POST http://localhost:8080/api/search/direct/orders/1 \
@@ -145,10 +148,11 @@ form, see [`point_time` in analytics](/build/analytics-with-sql/).
 
 ## Paging and sort (async)
 
-- `pageSize` and `pageNumber` are query parameters on the results
-  endpoint; `pageNumber` is zero-indexed.
-- Sort keys go in the submission body; the reference lists the
-  permitted keys per model.
+- `pageSize` and `pageNumber` are query parameters on
+  `/search/async/{jobId}/results`; they apply at result-fetch time,
+  not at job submission. `pageNumber` is zero-indexed.
+- Sort is not documented on the REST async surface at this release;
+  results are returned in insertion order.
 - A completed `jobId` is stable for its retention window — page
   reads are idempotent.
 

--- a/src/content/docs/build/searching-entities.md
+++ b/src/content/docs/build/searching-entities.md
@@ -42,11 +42,10 @@ The decision tree is short:
 Filter by a combination of entity fields and workflow state:
 
 ```bash
-curl -X POST http://localhost:8080/api/models/orders/search \
+curl -X POST http://localhost:8080/api/search/direct/orders/1 \
   -H 'Content-Type: application/json' \
   -H "Authorization: Bearer $TOKEN" \
   -d '{
-    "mode": "direct",
     "filter": {
       "state": "submitted",
       "customerId": "CUST-7"
@@ -54,34 +53,49 @@ curl -X POST http://localhost:8080/api/models/orders/search \
   }'
 ```
 
-The response is the list of matching entities, each with its current
-state, revision, and timestamps.
+The path is `/api/search/direct/{entityName}/{modelVersion}`. The response is
+the list of matching entities, each with its current state, revision, and
+timestamps.
 
 ## An async search
 
-Submit the search and capture the handle:
+Submit the search to `/api/search/async/{entityName}/{modelVersion}` and
+capture the handle:
 
 ```bash
-curl -X POST http://localhost:8080/api/models/orders/search \
+curl -X POST http://localhost:8080/api/search/async/orders/1 \
   -H 'Content-Type: application/json' \
   -H "Authorization: Bearer $TOKEN" \
   -d '{
-    "mode": "async",
-    "filter": { "state": "submitted" },
-    "pageSize": 1000
+    "filter": { "state": "submitted" }
   }'
 ```
 
-Poll the returned `searchId` until the job is ready, then fetch pages:
+Poll the returned `jobId` until the job is ready, then fetch pages
+(`pageNumber` is zero-indexed; `pageSize` caps the page):
 
 ```
-GET /api/search/{searchId}/status
-GET /api/search/{searchId}/results?page=0
-GET /api/search/{searchId}/results?page=1
+GET /api/search/async/{jobId}/status
+GET /api/search/async/{jobId}/results?pageNumber=0&pageSize=1000
+GET /api/search/async/{jobId}/results?pageNumber=1&pageSize=1000
 ```
 
-A single `searchId` can be paged repeatedly until the result is
+A single `jobId` can be paged repeatedly until the result is
 expired; expiry is controlled per deployment.
+
+### Cancelling a job
+
+If a job is no longer needed — the user navigated away, a replacement
+query was submitted, the deployment is shutting down — cancel it rather
+than letting it run to completion:
+
+```bash
+curl -X DELETE http://localhost:8080/api/search/async/{jobId}/cancel \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Cancellation is cooperative: in-flight work is stopped at the next safe
+point and any partial results for that `jobId` are discarded.
 
 ## Filter shape
 
@@ -114,11 +128,10 @@ as it existed at a given timestamp. The result is the set of entities
 that would have matched, using the revision active at that time.
 
 ```bash
-curl -X POST http://localhost:8080/api/models/orders/search \
+curl -X POST http://localhost:8080/api/search/direct/orders/1 \
   -H 'Content-Type: application/json' \
   -H "Authorization: Bearer $TOKEN" \
   -d '{
-    "mode": "direct",
     "pointInTime": "2026-03-01T00:00:00Z",
     "filter": { "state": "submitted", "customerId": "CUST-7" }
   }'
@@ -132,11 +145,11 @@ form, see [`point_time` in analytics](/build/analytics-with-sql/).
 
 ## Paging and sort (async)
 
-- `pageSize` is set at submission time; `page` is zero-indexed at read
-  time.
+- `pageSize` and `pageNumber` are query parameters on the results
+  endpoint; `pageNumber` is zero-indexed.
 - Sort keys go in the submission body; the reference lists the
   permitted keys per model.
-- A completed `searchId` is stable for its retention window — page
+- A completed `jobId` is stable for its retention window — page
   reads are idempotent.
 
 ## Performance notes

--- a/src/content/docs/build/testing-with-digital-twins.md
+++ b/src/content/docs/build/testing-with-digital-twins.md
@@ -51,7 +51,7 @@ makes the in-memory run a useful twin of the durable one.
 ## What stays the same, what changes
 
 Same:
-- API contracts (REST, gRPC, Trino).
+- API contracts (REST, gRPC today; Trino upcoming — see the [Trino reference](/reference/trino/)).
 - Workflow semantics: states, transitions, criteria, processors.
 - Event ordering within a transition.
 - Audit-trail shape.

--- a/src/content/docs/build/testing-with-digital-twins.md
+++ b/src/content/docs/build/testing-with-digital-twins.md
@@ -5,6 +5,11 @@ sidebar:
   order: 50
 ---
 
+In Cyoda, a "digital twin" means the same application code — workflows,
+criteria, processors — runs identically on every storage tier. Non-functional
+properties (persistence, latency, concurrency model) differ; business logic
+does not.
+
 cyoda-go's **in-memory mode** is the built-in test harness. It runs the entire
 platform — entity store, workflow engine, API surfaces — in a single process
 with no external dependencies and no disk writes. It is the fastest way to
@@ -14,8 +19,10 @@ scenario simulations against your application logic.
 ## In-memory mode as a test harness
 
 Start cyoda-go with the in-memory profile (or `go run ./cmd/cyoda` against the
-default in-memory config). Point your tests at it; tear it down between
-cases; no database to seed, no files to clean up.
+default in-memory config). Concretely: set `CYODA_STORAGE_BACKEND=memory`, or
+leave it unconfigured — memory is the application default until `cyoda init`
+is run. Point your tests at it; tear it down between cases; no database to
+seed, no files to clean up.
 
 Properties that matter for testing:
 

--- a/src/content/docs/build/workflows-and-processors.mdx
+++ b/src/content/docs/build/workflows-and-processors.mdx
@@ -41,7 +41,7 @@ You can find the workflow schema in the [API reference](/reference/api/). See th
 
 ```json
 {
-  "version": "1.0",
+  "version": "1",
   "name": "Workflow Name",
   "desc": "Workflow description",
   "initialState": "StateName",
@@ -63,7 +63,7 @@ You can find the workflow schema in the [API reference](/reference/api/). See th
 
 ### Multiple Workflows per Model
 
-An entity model can have multiple workflows, each with its own `criterion` at the workflow level. When an entity is created, the platform evaluates each active workflow's criterion to select the applicable workflow. This allows different processing paths for different categories of entities within the same model.
+An entity model can have multiple workflows, each with its own `criterion` at the workflow level. When an entity is created, the platform evaluates each active workflow's criterion to select the applicable workflow. The platform evaluates active workflows in the order they are defined and uses the first whose criterion matches (or the first with no criterion, which matches unconditionally). This allows different processing paths for different categories of entities within the same model.
 
 ## Import and Export
 
@@ -123,7 +123,7 @@ Transitions define allowed movements between states, optionally gated by conditi
 
 ### Manual vs Automated Transitions
 
-Transitions may be either **manual** or **automated**, and are guarded by criteria that determine their eligibility. When an entity enters a new state, the first eligible automated transition is executed immediately within the same transaction. This continues recursively until no further **automated** transitions are applicable, resulting in a stable state. Each transition may trigger one or more attached processes, which can run synchronously or asynchronously, either within the current transaction or in a separate one. This forms the foundation for event flow automation, where processors may create or mutate entities in response, allowing a single transition to initiate a cascade of events and function executions across the system.
+Transitions may be either **manual** or **automated**, and are guarded by criteria that determine their eligibility. When an entity enters a new state, the first eligible automated transition is executed immediately within the same transaction. This continues recursively until no further **automated** transitions are applicable, resulting in a stable state. Each transition may trigger one or more attached processes, which can run synchronously or asynchronously, either within the current transaction or in a separate one. This forms the foundation for event flow automation, where processors may create or mutate entities in response, allowing a single transition to initiate a cascade of events and function executions across the system. `CYODA_MAX_STATE_VISITS` configures the per-state visit limit within a single cascade (default 10). A separate hard-coded safety cap of 100 steps limits total cascade depth across all states, preventing runaway automatic-transition chains.
 
 ## Criteria
 
@@ -314,6 +314,8 @@ Externalized processors delegate execution to a calculation node via gRPC. This 
 - `ASYNC_SAME_TX`: Deferred within the current transaction. Commits or rolls back atomically with the triggering transition.
 - `ASYNC_NEW_TX`: Deferred execution in a separate, independent transaction. Default mode.
 
+Processors should be idempotent; failed ASYNC_NEW_TX processors may be retried.
+
 Synchronous executions run immediately and block the current processing thread on the same node, making them local and non-distributed. In contrast, asynchronous executions are scheduled for deferred processing and can be handled by any node in the cluster, enabling horizontal scalability and workload distribution, albeit with possibly somewhat higher latency.
 
 ### Scheduled Transition Processors
@@ -365,7 +367,7 @@ The following section walks through the configuration step by step.
 
 ```json
 {
-  "version": "1.0",
+  "version": "1",
   "name": "Payment Request Workflow",
   "desc": "Payment request processing workflow with validation, approval, and notification states",
   "initialState": "INVALID",
@@ -379,7 +381,7 @@ Start by defining the overall structure of states and transitions.
 
 ```json
 {
-  "version": "1.0",
+  "version": "1",
   "name": "Payment Request Workflow",
   "desc": "Payment request processing workflow with validation, approval, and notification states",
   "initialState": "INVALID",
@@ -464,7 +466,7 @@ We add criteria to the `VALIDATE` and `MATCH` transitions:
 
 ```json
 {
-  "version": "1.0",
+  "version": "1",
   "name": "Payment Request Workflow",
   "desc": "Payment request processing workflow with validation, approval, and notification states",
   "initialState": "INVALID",
@@ -567,7 +569,7 @@ We add two processors to the `APPROVE` transition in the `SUBMITTED` state, resp
 
 ```json
 {
-  "version": "1.0",
+  "version": "1",
   "name": "Payment Request Workflow",
   "desc": "Payment request processing workflow with validation, approval, and notification states",
   "initialState": "INVALID",

--- a/src/content/docs/build/working-with-entities.md
+++ b/src/content/docs/build/working-with-entities.md
@@ -30,7 +30,7 @@ Post an entity to its model. The first time you post, Cyoda discovers the
 schema from what you send:
 
 ```bash
-curl -X POST http://localhost:8080/api/models/orders/entities \
+curl -X POST http://localhost:8080/api/entity/JSON/orders/1 \
   -H 'Content-Type: application/json' \
   -H "Authorization: Bearer $TOKEN" \
   -d '{
@@ -44,32 +44,40 @@ curl -X POST http://localhost:8080/api/models/orders/entities \
   }'
 ```
 
-The response carries the entity's id, current state, and the revision number.
+The path is `/api/entity/{format}/{entityName}/{modelVersion}` — here `JSON`,
+`orders`, and version `1`. The response carries an array whose first element
+contains `entityIds[0]`, the **system-assigned UUID** of the new entity, plus
+its current state and revision number. Capture the UUID — downstream reads,
+updates, and transitions address the entity by that UUID, not by the business
+key `orderId`.
 
 ## Read
 
-Fetch the current revision by id:
+Fetch the current revision by id. The `{entityId}` in these URLs is the UUID
+returned in `entityIds[0]` from the create response, not a business key like
+`orderId`:
 
 ```bash
-curl http://localhost:8080/api/models/orders/entities/ORD-42 \
+curl http://localhost:8080/api/entity/${ENTITY_ID} \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-List with a filter — a short equality query returns the matching set:
+List every entity in a model with `GET /api/entity/{entityName}/{modelVersion}`:
 
 ```
-GET /api/models/orders/entities?state=submitted&customerId=CUST-7
+GET /api/entity/orders/1
 ```
 
-For anything beyond a bounded lookup — result caps, pagination,
-predicates, historical reads — see [searching entities](/build/searching-entities/).
+For filtered reads — predicates, pagination, result caps, historical reads —
+see [searching entities](/build/searching-entities/). The list endpoint does
+not accept ad-hoc field filters; those belong to search.
 
 ## Update
 
 Direct field updates go through `PATCH`:
 
 ```
-PATCH /api/models/orders/entities/ORD-42
+PATCH /api/entity/JSON/{entityId}
 ```
 
 However, **mutations that move the entity between lifecycle states should go
@@ -77,7 +85,7 @@ through a transition**, not a patch. Invoking the `submit` transition records
 it in the audit trail and runs any attached processors:
 
 ```
-POST /api/models/orders/entities/ORD-42/transitions/submit
+POST /api/entity/JSON/{entityId}/submit
 ```
 
 See [Build → workflows and processors](/build/workflows-and-processors/) for
@@ -111,7 +119,7 @@ Every entity's history is queryable. Add a `pointInTime` parameter to any read
 or search request to retrieve the world as of that timestamp:
 
 ```
-GET /api/models/orders/entities/ORD-42?pointInTime=2026-03-01T00:00:00Z
+GET /api/entity/{entityId}?pointInTime=2026-03-01T00:00:00Z
 ```
 
 This is the primary way to answer regulatory and audit questions: *what did

--- a/src/content/docs/build/working-with-entities.md
+++ b/src/content/docs/build/working-with-entities.md
@@ -82,10 +82,15 @@ PATCH /api/entity/JSON/{entityId}
 
 However, **mutations that move the entity between lifecycle states should go
 through a transition**, not a patch. Invoking the `submit` transition records
-it in the audit trail and runs any attached processors:
+it in the audit trail and runs any attached processors. The transition is a
+`PUT` whose body carries the new entity JSON (the platform stores the updated
+entity and records the named transition in one call):
 
-```
-POST /api/entity/JSON/{entityId}/submit
+```bash
+curl -X PUT http://localhost:8080/api/entity/JSON/${ENTITY_ID}/submit \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{ "orderId": "ORD-42", "status": "submitted" }'
 ```
 
 See [Build → workflows and processors](/build/workflows-and-processors/) for
@@ -95,20 +100,20 @@ how to declare transitions.
 
 Cyoda supports two query modes:
 
-- **Immediate** (API term: `direct`) — synchronous, returns right
-  away. Good for UI lookups and short operations. Result size is
-  capped, so `direct` is best for queries that produce a bounded,
-  small result set.
-- **Background** (API term: `async`) — queued as a job, returns a
-  handle you can poll. Result size is unbounded; results are paged.
-  Good for large result sets, periodic reports, and exports. On the
-  Cassandra-backed tier (Cyoda Cloud, or a licensed Enterprise
-  install), `async` search runs distributed across the cluster and
-  scales horizontally: query throughput for a fixed shape grows
-  roughly linearly with the number of nodes.
+- **Direct** (synchronous, capped result size) — API term `direct`.
+  Returns right away. Good for UI lookups and short operations.
+  Result size is capped, so `direct` is best for queries that produce
+  a bounded, small result set.
+- **Async** (background, unbounded, paged) — API term `async`.
+  Queued as a job, returns a handle you can poll. Result size is
+  unbounded; results are paged. Good for large result sets, periodic
+  reports, and exports. On the Cassandra-backed tier (Cyoda Cloud, or
+  a licensed Enterprise install), `async` search runs distributed
+  across the cluster and scales horizontally: query throughput for a
+  fixed shape grows roughly linearly with the number of nodes.
 
 Both accept the same filter grammar over entity fields, metadata, and
-workflow state. Pick immediate by default; switch to background when a
+workflow state. Pick `direct` by default; switch to `async` when a
 query would hit the `direct` result cap, would time out, or would hold
 resources you need elsewhere. For predicates, pagination, and worked
 examples, see [searching entities](/build/searching-entities/).

--- a/src/content/docs/concepts/apis-and-surfaces.md
+++ b/src/content/docs/concepts/apis-and-surfaces.md
@@ -55,6 +55,10 @@ For how to implement a compute node, see
 
 ## Trino SQL: cross-entity analytics
 
+:::caution[Upcoming]
+Trino SQL is on the roadmap and not yet available in cyoda-go at this release. The section below documents the planned surface; names and shapes may change before release.
+:::
+
 Use Trino when the question is *analytical* — joins across entity types,
 aggregates, reporting, time-series. Every entity model is projected into a
 set of virtual SQL tables; nested arrays and objects expand into separate

--- a/src/content/docs/concepts/apis-and-surfaces.md
+++ b/src/content/docs/concepts/apis-and-surfaces.md
@@ -20,6 +20,17 @@ matters; the surfaces are not equivalent, and each carries different guarantees.
   JDBC connections, BI tools. Queries run against a Trino catalogue that
   projects entities into virtual SQL tables.
 
+## Which surface, when?
+
+- Building a UI, an admin tool, or a sync integration? **REST.**
+- Writing a processor or criterion that runs against transitions? **gRPC.**
+- Running analytics, reports, or ad-hoc queries across many entities?
+  **Trino SQL.**
+
+All three surfaces are backed by the same entity store. A transition recorded
+via REST is visible to gRPC compute nodes and queryable through Trino, with
+the same audit trail behind it.
+
 ## REST: humans and services that speak to the platform
 
 Use REST when the call represents *a user or service interacting with the
@@ -75,14 +86,3 @@ and handling of polymorphic fields are in the
 [Trino SQL reference](/reference/trino/). For the Build-side quickstart —
 connection recipe, first query, performance notes — see
 [Analytics with SQL](/build/analytics-with-sql/).
-
-## Which surface, when?
-
-- Building a UI, an admin tool, or a sync integration? **REST.**
-- Writing a processor or criterion that runs against transitions? **gRPC.**
-- Running analytics, reports, or ad-hoc queries across many entities?
-  **Trino SQL.**
-
-All three surfaces are backed by the same entity store. A transition recorded
-via REST is visible to gRPC compute nodes and queryable through Trino, with
-the same audit trail behind it.

--- a/src/content/docs/concepts/authentication-and-identity.md
+++ b/src/content/docs/concepts/authentication-and-identity.md
@@ -38,7 +38,10 @@ When one service calls another on a user's behalf — a web app calling an API
 that calls a processor, for example — Cyoda supports **token exchange**. The
 calling service presents its own token plus the user's token and receives a
 new token scoped to the downstream call. This preserves the user identity
-through the chain without passing the original bearer token around.
+through the chain without passing the original bearer token around. In
+practice, the calling service includes the user's JWT as the `subject_token`
+in a token-exchange request; the issued token carries both identities for
+downstream authorization.
 
 The result: the audit trail records who the original user was at every hop,
 and each service still only sees a token scoped to what it is allowed to do.

--- a/src/content/docs/concepts/design-principles.mdx
+++ b/src/content/docs/concepts/design-principles.mdx
@@ -50,7 +50,7 @@ logs, and schema-lineage queries are all native operations.
 
 ## Events drive the machine
 
-Events — "file uploaded", "payment received", "clock tick" — trigger transitions.
+Events — "file uploaded", "payment received", "a manual transition issued by an operator" — trigger transitions.
 Transitions invoke processors. Processors can be synchronous or asynchronous, and
 can run inside or alongside the transition's transaction. The platform keeps the
 whole chain observable and replayable.

--- a/src/content/docs/concepts/workflows-and-events.md
+++ b/src/content/docs/concepts/workflows-and-events.md
@@ -60,6 +60,13 @@ Two flavours:
 Processors can run synchronously within the transition's transaction, or
 asynchronously alongside it.
 
+Processors run in one of three modes: **SYNC** (inline, shares the
+transition's transaction — failure aborts the transition), **ASYNC_SAME_TX**
+(runs asynchronously but in the same transaction context — failure still
+aborts), or **ASYNC_NEW_TX** (runs in a separate transaction via savepoint
+isolation — failure is logged and the transition succeeds). Choose the mode
+based on how atomically the side-effect must compose with the state change.
+
 ## Audit trail is the storage model
 
 Because every transition produces a revision and every processor invocation is

--- a/src/content/docs/getting-started/install-and-first-entity.mdx
+++ b/src/content/docs/getting-started/install-and-first-entity.mdx
@@ -123,7 +123,7 @@ see the [API reference](/reference/api/).
 
 <Aside type="tip" title="Testing without disk">
 If you want fast functional tests without durability, run cyoda-go in
-**in-memory** mode (`go run ./cmd/cyoda` or the `CYODA_STORAGE=memory` profile).
+**in-memory** mode (`go run ./cmd/cyoda` or the `CYODA_STORAGE_BACKEND=memory` profile).
 See [Testing with digital twins](/build/testing-with-digital-twins/) for the
 pattern.
 </Aside>

--- a/src/content/docs/getting-started/install-and-first-entity.mdx
+++ b/src/content/docs/getting-started/install-and-first-entity.mdx
@@ -47,10 +47,17 @@ Define a minimal model and push an entity. Cyoda discovers the schema from the
 sample you send, so you do not need to declare it up front:
 
 ```bash
-curl -X POST http://localhost:8080/api/models/orders/entities \
+ENTITY_ID=$(curl -s -X POST http://localhost:8080/api/entity/JSON/orders/1 \
   -H 'Content-Type: application/json' \
-  -d '{ "orderId": "ORD-1", "amount": 42.00, "currency": "EUR" }'
+  -d '{ "orderId": "ORD-1", "amount": 42.00, "currency": "EUR" }' \
+  | jq -r '.[0].entityIds[0]')
+echo "$ENTITY_ID"
 ```
+
+The create response is an array; `entityIds[0]` on the first element is the
+**system-assigned UUID** of the new entity. Subsequent reads and transitions
+address the entity by that UUID (`${ENTITY_ID}` here), not by the business
+key `orderId`.
 
 <Aside type="note" title="No token? That's expected locally.">
 Running `cyoda` (no subcommand) defaults to **mock auth** (`CYODA_IAM_MODE=mock`): every
@@ -92,10 +99,12 @@ For the full workflow schema — processors, criteria, automatic
 transitions, nested conditions — see
 [Build → workflows and processors](/build/workflows-and-processors/).
 
-Invoke the transition on your entity:
+Invoke the transition on your entity. `{entityId}` (here `${ENTITY_ID}`) is
+the system-assigned UUID captured from the create response, not the business
+key `orderId`:
 
 ```bash
-curl -X POST http://localhost:8080/api/models/orders/entities/ORD-1/transitions/submit
+curl -X POST http://localhost:8080/api/entity/JSON/${ENTITY_ID}/submit
 ```
 
 ## Read state back
@@ -103,7 +112,7 @@ curl -X POST http://localhost:8080/api/models/orders/entities/ORD-1/transitions/
 Fetch the current state and the transition log:
 
 ```bash
-curl http://localhost:8080/api/models/orders/entities/ORD-1
+curl http://localhost:8080/api/entity/${ENTITY_ID}
 ```
 
 The response shows the entity in its new `submitted` state plus a record of

--- a/src/content/docs/getting-started/install-and-first-entity.mdx
+++ b/src/content/docs/getting-started/install-and-first-entity.mdx
@@ -104,7 +104,7 @@ the system-assigned UUID captured from the create response, not the business
 key `orderId`:
 
 ```bash
-curl -X POST http://localhost:8080/api/entity/JSON/${ENTITY_ID}/submit
+curl -X PUT http://localhost:8080/api/entity/JSON/${ENTITY_ID}/submit
 ```
 
 ## Read state back

--- a/src/content/docs/getting-started/install-and-first-entity.mdx
+++ b/src/content/docs/getting-started/install-and-first-entity.mdx
@@ -40,7 +40,7 @@ you need active-active HA; see [Run → overview](/run/)).
 Start the server with the defaults:
 
 ```bash
-cyoda serve
+cyoda
 ```
 
 Define a minimal model and push an entity. Cyoda discovers the schema from the
@@ -53,7 +53,7 @@ curl -X POST http://localhost:8080/api/models/orders/entities \
 ```
 
 <Aside type="note" title="No token? That's expected locally.">
-`cyoda serve` defaults to **mock auth** (`CYODA_IAM_MODE=mock`): every
+Running `cyoda` (no subcommand) defaults to **mock auth** (`CYODA_IAM_MODE=mock`): every
 request is authenticated as a configurable default user, no bearer token
 required. You'll see examples elsewhere in the docs with
 `-H "Authorization: Bearer $TOKEN"`; those are written for production

--- a/src/content/docs/getting-started/install-and-first-entity.mdx
+++ b/src/content/docs/getting-started/install-and-first-entity.mdx
@@ -35,13 +35,72 @@ latency matters more than durability (use **in-memory** mode — see the callout
 below), and teams building production services (graduate to **PostgreSQL** when
 you need active-active HA; see [Run → overview](/run/)).
 
-## Your first entity
+## Start the server
 
 Start the server with the defaults:
 
 ```bash
 cyoda
 ```
+
+<Aside type="note" title="No token? That's expected locally.">
+Running `cyoda` (no subcommand) defaults to **mock auth** (`CYODA_IAM_MODE=mock`): every
+request is authenticated as a configurable default user, no bearer token
+required. You'll see examples elsewhere in the docs with
+`-H "Authorization: Bearer $TOKEN"`; those are written for production
+deployments running in JWT mode. On a fresh local install you can drop
+the header — or keep it and send any placeholder; mock mode ignores it.
+
+Flip to JWT mode by setting `CYODA_IAM_MODE=jwt` plus
+`CYODA_JWT_SIGNING_KEY` (RSA private key, PEM). For the full auth-mode
+configuration see [Configuration](/reference/configuration/).
+</Aside>
+
+## Import a workflow
+
+Before creating an entity, import a workflow so the platform knows which
+state machine to apply. Save this as `workflow.json` — two states
+(`draft` and `submitted`) with one manual transition. States are keyed by
+name; each state owns its outgoing transitions:
+
+```json
+{
+  "workflows": [
+    {
+      "version": "1",
+      "name": "orders-wf",
+      "initialState": "draft",
+      "active": true,
+      "states": {
+        "draft": {
+          "transitions": [
+            { "name": "submit", "next": "submitted", "manual": true }
+          ]
+        },
+        "submitted": {}
+      }
+    }
+  ]
+}
+```
+
+Post it to the import endpoint for the `orders` model at version `1`:
+
+```bash
+curl -X POST http://localhost:8080/api/model/orders/1/workflow/import \
+  -H 'Content-Type: application/json' \
+  -d @workflow.json
+```
+
+Without this step, cyoda-go applies its default workflow (`NONE` →
+`CREATED` → `DELETED` with a single automatic transition), and the
+`submit` transition used below will not exist.
+
+For the full workflow schema — processors, criteria, automatic
+transitions, nested conditions — see
+[Build → workflows and processors](/build/workflows-and-processors/).
+
+## Create your first entity
 
 Define a minimal model and push an entity. Cyoda discovers the schema from the
 sample you send, so you do not need to declare it up front:
@@ -59,49 +118,17 @@ The create response is an array; `entityIds[0]` on the first element is the
 address the entity by that UUID (`${ENTITY_ID}` here), not by the business
 key `orderId`.
 
-<Aside type="note" title="No token? That's expected locally.">
-Running `cyoda` (no subcommand) defaults to **mock auth** (`CYODA_IAM_MODE=mock`): every
-request is authenticated as a configurable default user, no bearer token
-required. You'll see examples elsewhere in the docs with
-`-H "Authorization: Bearer $TOKEN"`; those are written for production
-deployments running in JWT mode. On a fresh local install you can drop
-the header — or keep it and send any placeholder; mock mode ignores it.
+Automatic transitions (`manual: false`) fire immediately on creation,
+cascading the entity through applicable states until it reaches one with
+no outgoing auto transitions. The `orders-wf` workflow you just imported
+has none, so the entity settles in `draft` and waits for the manual
+`submit` transition below.
 
-Flip to JWT mode by setting `CYODA_IAM_MODE=jwt` plus
-`CYODA_JWT_SIGNING_KEY` (RSA private key, PEM). For the full auth-mode
-configuration see [Configuration](/reference/configuration/).
-</Aside>
+## Invoke a manual transition
 
-## Your first workflow
-
-Attach a workflow to the `orders` model with two states — `draft` and
-`submitted` — and one manual transition. States are keyed by name; each
-state owns its outgoing transitions:
-
-```json
-{
-  "version": "1",
-  "name": "orders-wf",
-  "initialState": "draft",
-  "active": true,
-  "states": {
-    "draft": {
-      "transitions": [
-        { "name": "submit", "next": "submitted", "manual": true }
-      ]
-    },
-    "submitted": {}
-  }
-}
-```
-
-For the full workflow schema — processors, criteria, automatic
-transitions, nested conditions — see
-[Build → workflows and processors](/build/workflows-and-processors/).
-
-Invoke the transition on your entity. `{entityId}` (here `${ENTITY_ID}`) is
-the system-assigned UUID captured from the create response, not the business
-key `orderId`:
+Trigger the `submit` transition on your entity. `{entityId}` (here
+`${ENTITY_ID}`) is the system-assigned UUID captured from the create
+response, not the business key `orderId`:
 
 ```bash
 curl -X PUT http://localhost:8080/api/entity/JSON/${ENTITY_ID}/submit

--- a/src/content/docs/reference/cli.mdx
+++ b/src/content/docs/reference/cli.mdx
@@ -18,6 +18,16 @@ cyoda <subcommand> --help
 ```
 
 The CLI exposes subcommands for initialising a store (`cyoda init`), serving
-(run `cyoda` with no subcommand — the default), and administration. Each subcommand's flags mirror the
-configuration environment variables; see
-[Configuration](/reference/configuration/) for the cross-reference.
+(run `cyoda` with no subcommand — the default), and administration.
+
+## Subcommands
+
+| Command | Purpose |
+|---------|---------|
+| `cyoda` | Start the server (default; no subcommand). |
+| `cyoda --help` / `-h` | Print help and exit. |
+| `cyoda init [--force]` | Write starter user config (SQLite default). Idempotent unless `--force`. |
+| `cyoda health` | Probe `/readyz` on the admin port; exit 0 on 200, 1 otherwise. |
+| `cyoda migrate [--timeout <duration>]` | Run storage-plugin migrations (no-op for memory / sqlite; Postgres runs plugin migrations). |
+
+Subcommand flags are operation-specific; they do not override server-runtime configuration (which comes from environment variables and `.env` files — see [Reference → Configuration](/reference/configuration/)).

--- a/src/content/docs/reference/cli.mdx
+++ b/src/content/docs/reference/cli.mdx
@@ -18,6 +18,6 @@ cyoda <subcommand> --help
 ```
 
 The CLI exposes subcommands for initialising a store (`cyoda init`), serving
-(`cyoda serve`), and administration. Each subcommand's flags mirror the
+(run `cyoda` with no subcommand — the default), and administration. Each subcommand's flags mirror the
 configuration environment variables; see
 [Configuration](/reference/configuration/) for the cross-reference.

--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -9,13 +9,17 @@ import VendoredBanner from '../../../components/VendoredBanner.astro';
 
 <VendoredBanner stability="awaiting-upstream" issue="https://github.com/Cyoda-platform/cyoda-go/issues/80" />
 
-cyoda-go reads configuration from three sources, with this precedence (later
-overrides earlier):
+cyoda-go reads configuration from the following sources:
 
-1. **Config file** — TOML/YAML at a default path, or passed via `--config`.
+1. **Config files** — `.env`-format only (godotenv-parsed). Loaded from system path, user path, and `.env` / `.env.{profile}` in the project directory. No TOML/YAML and no `--config` flag.
 2. **Environment variables** — prefixed `CYODA_`. Secrets support a `_FILE`
    suffix to read the value from a mounted file.
-3. **CLI flags** — the highest-precedence override for any single run.
+
+Configuration precedence (highest to lowest): shell environment > `.env.{profile}` > `.env` > user config > system config > hardcoded defaults. (Subcommands like `cyoda init` accept operation-specific flags that do NOT override server-runtime configuration.)
+
+`CYODA_PROFILES` is comma-separated and evaluated in declaration order; later profiles override earlier ones (within a profile, regular `.env` precedence applies).
+
+User config paths vary by OS: Linux/macOS `~/.config/cyoda/cyoda.env` (XDG), Windows `%AppData%\cyoda\cyoda.env`. System config lives at `/etc/cyoda/cyoda.env` on POSIX.
 
 The full reference — every key, its type, its default, and its environment
 variable form — will be generated from cyoda-go source. Until it is

--- a/src/content/docs/reference/entity-model-export.mdx
+++ b/src/content/docs/reference/entity-model-export.mdx
@@ -111,6 +111,11 @@ Array fields within an object node have keys ending in `[*]`:
 }
 ```
 
+The `(TYPE x WIDTH)` form is an array descriptor, where `TYPE` is the
+element type and `WIDTH` is the array length; e.g., `(INT x 4)` is a
+four-element integer array. See [Array type descriptors](#array-type-descriptors)
+for the full syntax.
+
 #### b) Structural fields — keys starting with `#`
 
 Structural fields are metadata markers prefixed with `#`. They indicate
@@ -136,6 +141,12 @@ Fields are sorted alphabetically within the object (data fields first,
 then structural fields, both sorted by key).
 
 ### 2. Array node (detached array)
+
+Arrays of arrays (multidimensional arrays beyond the first dimension)
+create detached array nodes — each inner array becomes its own node in
+the export tree, keyed by the path to that inner array (e.g.
+`$.matrix[*]`). Likewise, arrays of objects create a separate node for
+the element shape (see Examples 1 and 3).
 
 When a node path points to a pure array (no object fields at this
 level), the value is the array's **type descriptor** directly — either a
@@ -338,8 +349,7 @@ notation:
 
 Plain nested objects (non-array) are **inlined** into the parent node
 using dot-path notation (e.g., `.address.city`). They do not produce
-separate node entries or `#.fieldName` structural markers. Only arrays
-of objects create separate node entries (see Examples 1 and 3).
+separate node entries or `#.fieldName` structural markers.
 
 ### Example 3: Multi-dimensional array
 
@@ -599,9 +609,12 @@ arrays of integers.
    SIMPLE_VIEW always reflects the cumulative model.
 
 4. **Polymorphic types** use bracket notation `[TYPE1, TYPE2]` within a
-   single string. Types within the brackets are sorted by the internal
-   `ComparableDataType` ordering (roughly: more specific types first,
-   `STRING` last).
+   single string. Types within the brackets are sorted by the
+   `DataType` enum ordering defined in cyoda-go (see
+   `internal/domain/model/schema/types.go` for the authoritative rule):
+   numeric types first (integer families, then decimal families), then
+   text types (`STRING`, `CHARACTER`), then temporal, identifier,
+   binary, boolean, and `NULL` last.
 
 5. **UniTypeArray vs MultiTypeArray:** If all array elements have the
    same type, you get `(TYPE x N)`. If different positions have

--- a/src/content/docs/reference/trino.mdx
+++ b/src/content/docs/reference/trino.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import VendoredBanner from '../../../components/VendoredBanner.astro';
 
-<VendoredBanner stability="evolving" />
+<VendoredBanner stability="upcoming" />
 
 Cyoda exposes an analytical SQL surface through a Trino connector. Every
 entity model is projected into a set of **virtual SQL tables** so that

--- a/src/content/docs/run/desktop.md
+++ b/src/content/docs/run/desktop.md
@@ -54,7 +54,7 @@ cyoda-go reads configuration from environment variables, a config file, or
 CLI flags. The full list of options lives at
 [Reference → Configuration](/reference/configuration/); for everyday use
 the defaults are fine, and you only set a handful of variables
-(`CYODA_STORAGE`, listen ports, JWT keys) to adapt to your environment.
+(`CYODA_STORAGE_BACKEND`, listen ports, JWT keys) to adapt to your environment.
 
 For secrets, cyoda-go supports `*_FILE` suffixes on any credential
 environment variable so you can mount them from a secrets store rather than

--- a/src/content/docs/run/desktop.md
+++ b/src/content/docs/run/desktop.md
@@ -42,7 +42,7 @@ The Homebrew and packaged installers run `cyoda init` for you, which sets
 up the SQLite store. To start the server:
 
 ```bash
-cyoda serve
+cyoda
 ```
 
 The binary exposes REST on port **8080** and gRPC on **9090** by default.

--- a/src/content/docs/run/desktop.md
+++ b/src/content/docs/run/desktop.md
@@ -19,6 +19,8 @@ The desktop binary supports two storage modes:
   digital-twin scenario runs.
 - **SQLite (default)** — durable, single-file, zero-ops. Data survives
   restarts; backup is a file copy. Use it for everyday persistent work.
+  SQLite is single-writer; all writes serialize through the database file,
+  which limits concurrent write throughput.
 
 The SQLite database file is created at `~/.local/share/cyoda/cyoda.db` by
 `cyoda init`. Back it up by copying the file; migrate it by moving the file.
@@ -60,13 +62,6 @@ For secrets, cyoda-go supports `*_FILE` suffixes on any credential
 environment variable so you can mount them from a secrets store rather than
 pass them on the command line.
 
-## Upgrading
-
-Upgrading is a version bump: install the new binary, restart the process.
-cyoda-go follows semantic versioning; configuration migration policy is
-documented in the
-[cyoda-go release notes](https://github.com/cyoda-platform/cyoda-go/releases).
-
 ## When you outgrow desktop
 
 Three signs you've outgrown this tier:
@@ -82,3 +77,10 @@ When any of those apply, move up:
 - **[Docker](./docker/)** — same binary, containerised.
 - **[Kubernetes](./kubernetes/)** — active-active cluster on PostgreSQL.
 - **[Cyoda Cloud](./cyoda-cloud/)** — managed service.
+
+## Upgrading
+
+Upgrading is a version bump: install the new binary, restart the process.
+cyoda-go follows semantic versioning; configuration migration policy is
+documented in the
+[cyoda-go release notes](https://github.com/cyoda-platform/cyoda-go/releases).

--- a/src/content/docs/run/docker.md
+++ b/src/content/docs/run/docker.md
@@ -39,9 +39,11 @@ cyoda-go release and we link whichever is current.
 ## PostgreSQL backend
 
 Point cyoda-go at a PostgreSQL instance by setting `CYODA_STORAGE_BACKEND=postgres`
-and the usual connection variables (or `*_FILE` forms for secrets). The
-Docker compose example wires this up end-to-end; for production you will
-run PostgreSQL separately and pass only the DSN.
+and the usual connection variables (or `*_FILE` forms for secrets). The DSN
+goes in `CYODA_POSTGRES_URL` (or `CYODA_POSTGRES_URL_FILE` for a file-mounted
+secret per Docker conventions). The Docker compose example wires this up
+end-to-end; for production you will run PostgreSQL separately and pass only
+the DSN.
 
 ## Observability
 
@@ -56,6 +58,16 @@ The observability example demonstrates a full loop:
 Tune sampling and log level at runtime via the admin endpoints;
 see the
 [cyoda-go observability reference](https://github.com/cyoda-platform/cyoda-go#observability).
+
+Health probes live on the admin port (default 9091): `/livez` (liveness) and
+`/readyz` (readiness). Both are unauthenticated.
+
+## Data directory
+
+The container pre-stages `/var/lib/cyoda` as the data directory (with the
+correct ownership for the non-root `65532:65532` user). Mount it as a named
+volume if you want SQLite data or any plugin state to persist across
+container restarts.
 
 ## When you outgrow a single node
 

--- a/src/content/docs/run/docker.md
+++ b/src/content/docs/run/docker.md
@@ -38,7 +38,7 @@ cyoda-go release and we link whichever is current.
 
 ## PostgreSQL backend
 
-Point cyoda-go at a PostgreSQL instance by setting `CYODA_STORAGE=postgres`
+Point cyoda-go at a PostgreSQL instance by setting `CYODA_STORAGE_BACKEND=postgres`
 and the usual connection variables (or `*_FILE` forms for secrets). The
 Docker compose example wires this up end-to-end; for production you will
 run PostgreSQL separately and pass only the DSN.

--- a/src/content/docs/run/kubernetes.md
+++ b/src/content/docs/run/kubernetes.md
@@ -41,8 +41,9 @@ stateful dependency.
 ```
 
 Every pod is identical; any pod can serve any request. There is no leader
-election, no ZooKeeper, no etcd. Writes are coordinated through PostgreSQL's
-`SERIALIZABLE` isolation so concurrent writers never silently corrupt data.
+election, no ZooKeeper, no etcd. Coordination happens through PostgreSQL's
+SERIALIZABLE isolation for writes and a gossip protocol (HMAC-authenticated)
+for membership, so concurrent writers never silently corrupt data.
 
 ## Helm chart
 
@@ -52,9 +53,13 @@ The chart provisions the cyoda-go Deployment, a Service, a ConfigMap for
 non-sensitive configuration, and Secret references for credentials.
 
 The authoritative values reference lives under
-[Reference → Helm values](/reference/helm/) (awaiting upstream at the time of
-writing); the chart's own `values.yaml` is the source of truth until that
-reference is published.
+[Reference → Helm values](/reference/helm/); the chart's own `values.yaml`
+remains the runtime source of truth.
+
+The Helm chart auto-generates the HMAC secret unless
+`cluster.hmacSecret.existingSecret` is provided. GitOps deployments should
+always set `existingSecret` to avoid Helm rendering a fresh secret on every
+reconcile, which would cause inter-node auth to drift.
 
 ## High availability
 
@@ -83,7 +88,9 @@ cyoda-go releases follow semantic versioning. For production:
   capacity never drops.
 - **Schema migration ordering.** Check the release notes for whether a
   release requires a PostgreSQL schema migration step before the new binary
-  starts serving.
+  starts serving. The Helm chart runs schema migrations as a
+  pre-install/pre-upgrade hook; pod startup is blocked until migrations
+  complete.
 
 ## Sizing
 


### PR DESCRIPTION
## Summary
- Apply all 20 Fix-now findings and 36 clarity suggestions from the 2026-04-22 correctness review.
- Four site-wide sweeps fix the highest-leverage issues in one pass each:
  - **Trino upcoming banner** on 4 pages (concepts/apis-and-surfaces, build/analytics-with-sql, build/testing-with-digital-twins, reference/trino). Trino is on the roadmap; correctness of specifics deferred until the feature ships.
  - **`/api/models/...` → `/api/entity/...` / `/api/search/...`** endpoint paths across 3 pages (plus the `{searchId}` → `{jobId}` rename and the PUT-vs-POST transition correction).
  - **Phantom `cyoda serve` subcommand** removed from 4 occurrences — the binary starts with bare `cyoda`.
  - **`CYODA_STORAGE` → `CYODA_STORAGE_BACKEND`** env var typo fixed on 3 pages.
- Extend `VendoredBanner.astro` with a new `'upcoming'` stability mode for roadmap-feature pages.
- Per-page Fix-now residuals and clarity bundles across concepts, build, run, reference, and the getting-started onramp.

Reframe-post-#80 (5 items) and Delete-post-#80 (1 item) are **not** included — those wait for cyoda-go #80 and land in the follow-up reframe PR (cyoda-docs #69).

## Review input
- Spec: `docs/superpowers/specs/2026-04-22-cyoda-docs-correctness-review-design.md`
- Plan: `docs/superpowers/plans/2026-04-22-cyoda-docs-correctness-fixes.md`
- Review artefacts: `docs/superpowers/reviews/2026-04-22-correctness/` (README, ledger, 29 per-page reviews, 5 section summaries, cross-cutting synthesis)

## Test plan
- [x] `ASTRO_TELEMETRY_DISABLED=1 npm run build` succeeds (101 pages; schema pages, markdown export, llms.txt, schemas.zip all produced).
- [x] `npx playwright test tests/link-integrity.spec.ts` — 5/5 passed.
- [ ] Full `npm test` (GDPR + GA Playwright suite) — untouched by this PR's changes; verify in CI.
- [ ] Visual check: open `http://localhost:4321/` via `npm run dev` and confirm the Trino "upcoming" banner renders on the four affected pages.
- [ ] Spot-check the corrected curl examples against a live `cyoda-go`: `cyoda` (start server) → `curl -X POST /api/model/orders/1/workflow/import` (import workflow) → `curl -X POST /api/entity/JSON/orders/1` (create) → `curl -X PUT /api/entity/JSON/${ENTITY_ID}/submit` (transition) → `curl /api/entity/${ENTITY_ID}` (read).

## Base branch note
This PR targets `feature/cyoda-go-init`, not `main`. `main` is production and holds the current site; `feature/cyoda-go-init` is the long-running integration branch awaiting QA before eventual merge to `main`.