### PR TITLE
docs/landing: hero rewrite, code-panel cleanup, aside palette, link-style pass

### DIFF
--- a/public/styles/non-critical.css
+++ b/public/styles/non-critical.css
@@ -136,7 +136,7 @@
  * Default state shows a purple underline (not transparent) so the
  * link affordance is visible without hover. Hover swaps to aqua.
  */
-.sl-markdown-content a[href]:not(.cyoda-btn) {
+.sl-markdown-content a[href]:not(.cyoda-btn):not(.sl-anchor-link) {
   color: var(--cyoda-aqua);
   text-decoration: none;
   border-bottom: 1px solid transparent;
@@ -145,12 +145,18 @@
 
 /* Affordance: trailing arrow signals "goes somewhere" without an
  * underline. Non-breaking space keeps the arrow attached to the
- * last word of the link when wrapping. */
-.sl-markdown-content a[href]:not(.cyoda-btn)::after {
+ * last word of the link when wrapping.
+ *
+ * `:not(.sl-anchor-link)` excludes Starlight's heading anchor icons:
+ * they have their own absolutely-positioned `::after` used as an
+ * invisible click-target overlay, and overriding its `content`
+ * would stretch the arrow across the heading area.
+ */
+.sl-markdown-content a[href]:not(.cyoda-btn):not(.sl-anchor-link)::after {
   content: "\00a0→";
 }
 
-.sl-markdown-content a[href]:not(.cyoda-btn):hover {
+.sl-markdown-content a[href]:not(.cyoda-btn):not(.sl-anchor-link):hover {
   border-bottom-color: var(--cyoda-aqua);
 }
 

--- a/public/styles/non-critical.css
+++ b/public/styles/non-critical.css
@@ -127,15 +127,23 @@
  *
  * :not(.cyoda-btn) excludes button-styled anchors so their own
  * border declarations aren't clobbered on the bottom edge.
+ *
+ * [href] bumps specificity to 0,2,1 so we win against Starlight's
+ * own `.sl-markdown-content a:not(:where(.not-content *))` rule
+ * (0,1,1) that otherwise paints links in the generic body-text
+ * accent colour, making them indistinguishable from prose.
+ *
+ * Default state shows a purple underline (not transparent) so the
+ * link affordance is visible without hover. Hover swaps to aqua.
  */
-.sl-markdown-content a:not(.cyoda-btn) {
-  color: var(--cyoda-purple);
+.sl-markdown-content a[href]:not(.cyoda-btn) {
+  color: hsl(var(--cyoda-purple));
   text-decoration: none;
-  border-bottom: 1px solid transparent;
+  border-bottom: 1px solid hsl(var(--cyoda-purple));
   transition: all 0.2s ease;
 }
 
-.sl-markdown-content a:not(.cyoda-btn):hover {
+.sl-markdown-content a[href]:not(.cyoda-btn):hover {
   color: var(--cyoda-aqua);
   border-bottom-color: var(--cyoda-aqua);
 }

--- a/public/styles/non-critical.css
+++ b/public/styles/non-critical.css
@@ -123,15 +123,19 @@
   color: var(--cyoda-aqua);
 }
 
-/* Links - Non-critical */
-.sl-markdown-content a {
+/* Links - Non-critical
+ *
+ * :not(.cyoda-btn) excludes button-styled anchors so their own
+ * border declarations aren't clobbered on the bottom edge.
+ */
+.sl-markdown-content a:not(.cyoda-btn) {
   color: var(--cyoda-purple);
   text-decoration: none;
   border-bottom: 1px solid transparent;
   transition: all 0.2s ease;
 }
 
-.sl-markdown-content a:hover {
+.sl-markdown-content a:not(.cyoda-btn):hover {
   color: var(--cyoda-aqua);
   border-bottom-color: var(--cyoda-aqua);
 }

--- a/public/styles/non-critical.css
+++ b/public/styles/non-critical.css
@@ -149,7 +149,9 @@
 .sl-markdown-content a[href]:not(.cyoda-btn):not(.sl-anchor-link) {
   color: hsl(178 40% 30%);
   text-decoration: none;
-  border-bottom: 1px solid transparent;
+  /* Default underline is the non-colour link affordance (WCAG 1.4.1).
+   * Since the arrow is opt-in, links need a visible cue without hover. */
+  border-bottom: 1px solid hsl(178 40% 30%);
   transition: all 0.2s ease;
 }
 
@@ -159,7 +161,9 @@
 }
 
 .sl-markdown-content a[href]:not(.cyoda-btn):not(.sl-anchor-link):hover {
-  border-bottom-color: hsl(178 40% 30%);
+  /* Hover pops to the brand aqua for interactive feedback */
+  color: var(--cyoda-aqua);
+  border-bottom-color: var(--cyoda-aqua);
 }
 
 /* Button and interactive elements - Non-critical */

--- a/public/styles/non-critical.css
+++ b/public/styles/non-critical.css
@@ -137,14 +137,20 @@
  * link affordance is visible without hover. Hover swaps to aqua.
  */
 .sl-markdown-content a[href]:not(.cyoda-btn) {
-  color: hsl(var(--cyoda-purple));
+  color: var(--cyoda-aqua);
   text-decoration: none;
-  border-bottom: 1px solid hsl(var(--cyoda-purple));
+  border-bottom: 1px solid transparent;
   transition: all 0.2s ease;
 }
 
+/* Affordance: trailing arrow signals "goes somewhere" without an
+ * underline. Non-breaking space keeps the arrow attached to the
+ * last word of the link when wrapping. */
+.sl-markdown-content a[href]:not(.cyoda-btn)::after {
+  content: "\00a0→";
+}
+
 .sl-markdown-content a[href]:not(.cyoda-btn):hover {
-  color: var(--cyoda-aqua);
   border-bottom-color: var(--cyoda-aqua);
 }
 

--- a/public/styles/non-critical.css
+++ b/public/styles/non-critical.css
@@ -125,39 +125,41 @@
 
 /* Links - Non-critical
  *
- * :not(.cyoda-btn) excludes button-styled anchors so their own
- * border declarations aren't clobbered on the bottom edge.
+ * Exclusions:
+ *   :not(.cyoda-btn)       — button-styled anchors keep their own border
+ *   :not(.sl-anchor-link)  — Starlight heading-anchor chain icons have an
+ *                            absolutely-positioned ::after used as a click-
+ *                            target overlay; we mustn't stretch a glyph
+ *                            across it.
  *
- * [href] bumps specificity to 0,2,1 so we win against Starlight's
- * own `.sl-markdown-content a:not(:where(.not-content *))` rule
- * (0,1,1) that otherwise paints links in the generic body-text
- * accent colour, making them indistinguishable from prose.
+ * Specificity: `[href]` bumps the selector to 0,3,1 so we win against
+ * Starlight's own `.sl-markdown-content a:not(:where(.not-content *))`
+ * (0,1,1, layered) which otherwise paints links in the generic body
+ * accent colour.
  *
- * Default state shows a purple underline (not transparent) so the
- * link affordance is visible without hover. Hover swaps to aqua.
+ * Default state: darkened teal colour (hsl(178 40% 30%) ≈ 5.5:1 on
+ * white — passes WCAG AA 4.5:1 for body text), no underline. Hover
+ * reveals a matching underline via `border-bottom-color`.
+ *
+ * Trailing-arrow affordance is OPT-IN via the `cta` class — keep it
+ * sparing. Inline body-text references shouldn't sprout arrows mid-
+ * sentence; arrows are for links that genuinely read as "follow me
+ * somewhere" (read-more callouts, section-level links, external CTAs).
  */
 .sl-markdown-content a[href]:not(.cyoda-btn):not(.sl-anchor-link) {
-  color: var(--cyoda-aqua);
+  color: hsl(178 40% 30%);
   text-decoration: none;
   border-bottom: 1px solid transparent;
   transition: all 0.2s ease;
 }
 
-/* Affordance: trailing arrow signals "goes somewhere" without an
- * underline. Non-breaking space keeps the arrow attached to the
- * last word of the link when wrapping.
- *
- * `:not(.sl-anchor-link)` excludes Starlight's heading anchor icons:
- * they have their own absolutely-positioned `::after` used as an
- * invisible click-target overlay, and overriding its `content`
- * would stretch the arrow across the heading area.
- */
-.sl-markdown-content a[href]:not(.cyoda-btn):not(.sl-anchor-link)::after {
+.sl-markdown-content a[href]:not(.cyoda-btn):not(.sl-anchor-link).cta::after {
+  /* Non-breaking space keeps the arrow glued to the last word when wrapping */
   content: "\00a0→";
 }
 
 .sl-markdown-content a[href]:not(.cyoda-btn):not(.sl-anchor-link):hover {
-  border-bottom-color: var(--cyoda-aqua);
+  border-bottom-color: hsl(178 40% 30%);
 }
 
 /* Button and interactive elements - Non-critical */

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -15,10 +15,12 @@ const { href, variant = 'primary' } = Astro.props;
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
-    padding: 0.6rem 1.25rem;
+    padding: 0.45rem 1rem;
     border-radius: 0.4rem;
     font-family: var(--cyoda-font-sans);
+    font-size: 0.9375rem;
     font-weight: 600;
+    line-height: 1.3;
     text-decoration: none;
     transition: background 160ms ease, color 160ms ease, border-color 160ms ease;
   }

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -38,5 +38,5 @@ robust production workloads.
 - **New here?** Start with the [install-and-first-entity onramp](/getting-started/install-and-first-entity/).
 - **Understanding Cyoda?** Read [Concepts](/concepts/what-is-cyoda/).
 - **Building an app?** [Build](/build/) covers tier-agnostic patterns.
-- **Running one?** [Run](/run/) covers desktop, Docker, Kubernetes, and Cyoda Cloud.
-- **Need API specs?** [Reference](/reference/) embeds and ingests from cyoda-go.
+- **Running one?** [Run](/run/) covers [desktop](/run/desktop/), [Docker](/run/docker/), [Kubernetes](/run/kubernetes/), and [Cyoda Cloud](/run/cyoda-cloud/).
+- **Need API specs?** [Reference](/reference/) embeds and ingests from [cyoda-go](https://github.com/Cyoda-platform/cyoda-go).

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -8,14 +8,14 @@ import Button from '../../components/Button.astro';
 import GrowthPathDiagram from '../../components/GrowthPathDiagram.astro';
 
 <div class="section-hero">
-  <Badge variant="teal" size="sm">Developer platform · digital twins</Badge>
+  <Badge variant="teal" size="sm">EDBMS — Entity Database Management System</Badge>
 
-  # Build once. Run anywhere on the growth path.
+  # One transactional runtime for state, workflow, events, and audit.
 
-  State, workflow, transactions, events, history, and business logic as a
-  single first-class abstraction. Write your app against cyoda-go locally,
-  promote to PostgreSQL in production, or let Cyoda Cloud run it at
-  enterprise scale.
+  Cyoda is an EDBMS: state machine, processors, and full revision history
+  live inside the record, committed atomically — minimizing the need for
+  sagas. A simpler stack than Postgres + Temporal + Kafka + a CDC audit
+  pipeline. Open source, single Go binary, Postgres-backed.
 
   <Button href="/getting-started/install-and-first-entity/" variant="primary">Get started</Button>
   <Button href="/concepts/what-is-cyoda/" variant="secondary">Learn the concepts</Button>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -10,12 +10,13 @@ import GrowthPathDiagram from '../../components/GrowthPathDiagram.astro';
 <div class="section-hero">
   <Badge variant="teal" size="sm">EDBMS — Entity Database Management System</Badge>
 
-  # One transactional runtime for state, workflow, events, and audit.
+  # One transactional runtime for the entity lifecycle.
 
   Cyoda is an EDBMS: state machine, processors, and full revision history
   live inside the record, committed atomically — minimizing the need for
   sagas. A simpler stack than Postgres + Temporal + Kafka + a CDC audit
-  pipeline. Open source, single Go binary, Postgres-backed.
+  pipeline. Build complete event-driven backends on one runtime. Open
+  source, single Go binary, Postgres-backed.
 
   <Button href="/getting-started/install-and-first-entity/" variant="primary">Get started</Button>
   <Button href="/concepts/what-is-cyoda/" variant="secondary">Learn the concepts</Button>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -22,6 +22,13 @@ import GrowthPathDiagram from '../../components/GrowthPathDiagram.astro';
   <Button href="/concepts/what-is-cyoda/" variant="secondary">Learn the concepts</Button>
 </div>
 
+## Four storage engines. One application contract.
+
+Three open-source engines ship with cyoda-go — in-memory, SQLite, and
+PostgreSQL — each tuned to a different operational shape. A commercial
+Cassandra plugin extends the same application code to fully scalable,
+robust production workloads.
+
 <GrowthPathDiagram />
 
 <div class="section-separator" />

--- a/src/content/docs/run/cyoda-cloud/provisioning.mdx
+++ b/src/content/docs/run/cyoda-cloud/provisioning.mdx
@@ -38,9 +38,9 @@ Getting your first Cyoda Cloud Free Tier environment is very straightforward. Si
 
 1. **Access the AI Studio**: Navigate to the Cyoda Cloud web-based Single Page Application (SPA) at [https://ai.cyoda.net](https://ai.cyoda.net) and consent to the terms and conditions.
 
-<Image src={aiAssistantConsent} alt="AI Studio Consent" width={600} height={450} loading="lazy" />
+<Image src={aiAssistantConsent} alt="AI Studio Consent" loading="lazy" class="screenshot" />
 
-<Image src={aiAssistantGreet} alt="AI Studio Greeting Screen" width={600} height={450} loading="lazy" />
+<Image src={aiAssistantGreet} alt="AI Studio Greeting Screen" loading="lazy" class="screenshot" />
 
 2. **Choose Authentication Provider**: Register using one of the supported providers:
     - **Google Auth**: Sign up using your Google account
@@ -52,7 +52,7 @@ Getting your first Cyoda Cloud Free Tier environment is very straightforward. Si
 
 Prompt in the chat dialogue of the AI Studio with: `What is my environment URL?`. Wait a bit.
 
-<Image src={whatIsMyEnvironment} alt="What is my environment URL Prompt" width={600} height={450} loading="lazy" />
+<Image src={whatIsMyEnvironment} alt="What is my environment URL Prompt" loading="lazy" class="screenshot" />
 
 
 ## Deploy your Environment
@@ -61,9 +61,9 @@ Prompt with: `Deploy my environment`.
 
 Wait for the deployment to complete. It usually takes about 5 minutes.
 
-<Image src={deployEnvPrompt} alt="Deploy Environment Prompt" width={600} height={450} loading="lazy" />
+<Image src={deployEnvPrompt} alt="Deploy Environment Prompt" loading="lazy" class="screenshot" />
 
-<Image src={envDeployedConfirmation} alt="Environment Deployed Confirmation" width={600} height={450} loading="lazy" />
+<Image src={envDeployedConfirmation} alt="Environment Deployed Confirmation" loading="lazy" class="screenshot" />
 
 ## Create a Technical User
 
@@ -71,7 +71,7 @@ Wait for the deployment to complete. It usually takes about 5 minutes.
 You will see a button to launch the query against your env to create a new user.
 Write down the client ID and secret - you'll need them to access your environment.
 
-<Image src={createTechnicalUser} alt="Add Machine User Prompt" width={600} height={450} loading="lazy" />
+<Image src={createTechnicalUser} alt="Add Machine User Prompt" loading="lazy" class="screenshot" />
 
 
 ## Access the Environment
@@ -82,11 +82,11 @@ Once your environment is deployed and you have a technical user, you can access 
 Just navigate to your environment URL in your favorite browser at `https://client-<your_caas_user_id>.eu.cyoda.net`
 You can find your environment URL from the previous steps or ask in chat for the url
 
-<Image src={loginCyodaUI} alt="Login Cyoda UI" width={600} height={450} loading="lazy" />
+<Image src={loginCyodaUI} alt="Login Cyoda UI" loading="lazy" class="screenshot" />
 
 With the Cyoda UI you need to login with your personal via Auth0.
 
-<Image src={loggedIn} alt="Cyoda UI Logged In" width={600} height={450} loading="lazy" />
+<Image src={loggedIn} alt="Cyoda UI Logged In" loading="lazy" class="screenshot" />
 
 ### Via the API
 To access the APIs you need to use your technical user credentials to authenticate.

--- a/src/content/docs/run/cyoda-cloud/provisioning.mdx
+++ b/src/content/docs/run/cyoda-cloud/provisioning.mdx
@@ -38,9 +38,9 @@ Getting your first Cyoda Cloud Free Tier environment is very straightforward. Si
 
 1. **Access the AI Studio**: Navigate to the Cyoda Cloud web-based Single Page Application (SPA) at [https://ai.cyoda.net](https://ai.cyoda.net) and consent to the terms and conditions.
 
-<Image src={aiAssistantConsent} alt="AI Studio Consent" width={800} height={600} loading="lazy" />
+<Image src={aiAssistantConsent} alt="AI Studio Consent" width={600} height={450} loading="lazy" />
 
-<Image src={aiAssistantGreet} alt="AI Studio Greeting Screen" width={800} height={600} loading="lazy" />
+<Image src={aiAssistantGreet} alt="AI Studio Greeting Screen" width={600} height={450} loading="lazy" />
 
 2. **Choose Authentication Provider**: Register using one of the supported providers:
     - **Google Auth**: Sign up using your Google account
@@ -52,7 +52,7 @@ Getting your first Cyoda Cloud Free Tier environment is very straightforward. Si
 
 Prompt in the chat dialogue of the AI Studio with: `What is my environment URL?`. Wait a bit.
 
-<Image src={whatIsMyEnvironment} alt="What is my environment URL Prompt" width={800} height={600} loading="lazy" />
+<Image src={whatIsMyEnvironment} alt="What is my environment URL Prompt" width={600} height={450} loading="lazy" />
 
 
 ## Deploy your Environment
@@ -61,9 +61,9 @@ Prompt with: `Deploy my environment`.
 
 Wait for the deployment to complete. It usually takes about 5 minutes.
 
-<Image src={deployEnvPrompt} alt="Deploy Environment Prompt" width={800} height={600} loading="lazy" />
+<Image src={deployEnvPrompt} alt="Deploy Environment Prompt" width={600} height={450} loading="lazy" />
 
-<Image src={envDeployedConfirmation} alt="Environment Deployed Confirmation" width={800} height={600} loading="lazy" />
+<Image src={envDeployedConfirmation} alt="Environment Deployed Confirmation" width={600} height={450} loading="lazy" />
 
 ## Create a Technical User
 
@@ -71,7 +71,7 @@ Wait for the deployment to complete. It usually takes about 5 minutes.
 You will see a button to launch the query against your env to create a new user.
 Write down the client ID and secret - you'll need them to access your environment.
 
-<Image src={createTechnicalUser} alt="Add Machine User Prompt" width={800} height={600} loading="lazy" />
+<Image src={createTechnicalUser} alt="Add Machine User Prompt" width={600} height={450} loading="lazy" />
 
 
 ## Access the Environment
@@ -82,11 +82,11 @@ Once your environment is deployed and you have a technical user, you can access 
 Just navigate to your environment URL in your favorite browser at `https://client-<your_caas_user_id>.eu.cyoda.net`
 You can find your environment URL from the previous steps or ask in chat for the url
 
-<Image src={loginCyodaUI} alt="Login Cyoda UI" width={800} height={600} loading="lazy" />
+<Image src={loginCyodaUI} alt="Login Cyoda UI" width={600} height={450} loading="lazy" />
 
 With the Cyoda UI you need to login with your personal via Auth0.
 
-<Image src={loggedIn} alt="Cyoda UI Logged In" width={800} height={600} loading="lazy" />
+<Image src={loggedIn} alt="Cyoda UI Logged In" width={600} height={450} loading="lazy" />
 
 ### Via the API
 To access the APIs you need to use your technical user credentials to authenticate.

--- a/src/content/docs/run/desktop.md
+++ b/src/content/docs/run/desktop.md
@@ -62,22 +62,6 @@ For secrets, cyoda-go supports `*_FILE` suffixes on any credential
 environment variable so you can mount them from a secrets store rather than
 pass them on the command line.
 
-## When you outgrow desktop
-
-Three signs you've outgrown this tier:
-
-- **Concurrency.** Single-process SQLite serialises writes; if your workload
-  is write-hot you will see contention.
-- **HA requirements.** A desktop binary is a single point of failure.
-- **Operational scale.** Once you are running many instances, you want
-  orchestration.
-
-When any of those apply, move up:
-
-- **[Docker](./docker/)** — same binary, containerised.
-- **[Kubernetes](./kubernetes/)** — active-active cluster on PostgreSQL.
-- **[Cyoda Cloud](./cyoda-cloud/)** — managed service.
-
 ## Upgrading
 
 Upgrading is a version bump: install the new binary, restart the process.

--- a/src/content/docs/run/docker.md
+++ b/src/content/docs/run/docker.md
@@ -69,7 +69,3 @@ correct ownership for the non-root `65532:65532` user). Mount it as a named
 volume if you want SQLite data or any plugin state to persist across
 container restarts.
 
-## When you outgrow a single node
-
-A single Docker host is a single point of failure. Production HA wants
-Kubernetes; see [Kubernetes](./kubernetes/).

--- a/src/content/docs/run/kubernetes.md
+++ b/src/content/docs/run/kubernetes.md
@@ -45,6 +45,11 @@ election, no ZooKeeper, no etcd. Coordination happens through PostgreSQL's
 SERIALIZABLE isolation for writes and a gossip protocol (HMAC-authenticated)
 for membership, so concurrent writers never silently corrupt data.
 
+The stateful backend is pluggable: PostgreSQL (OSS default) or the
+commercial Cassandra storage engine. The pod topology and the application
+contract are identical either way — only the storage plugin configuration
+differs.
+
 ## Helm chart
 
 cyoda-go ships a Helm chart under
@@ -102,8 +107,9 @@ Qualitative guide:
   transitions per second.
 - **Medium.** 5–7 pods, dedicated PostgreSQL, low thousands of
   transitions per second.
-- **Large.** 10 pods with PostgreSQL scaled up; you are usually at a point
-  where Cyoda Cloud's Cassandra backend is worth evaluating.
+- **Large.** 10 pods with PostgreSQL scaled up; at this point consider
+  swapping to the commercial Cassandra storage engine (still on
+  Kubernetes), or handing operations to Cyoda Cloud as a SaaS.
 
 ## Observability
 
@@ -112,9 +118,20 @@ the admin endpoints for log-level and tracing control. Standard
 OpenTelemetry configuration applies; wire OTLP exporters via environment
 variables in the Helm values.
 
-## When you outgrow Kubernetes
+## Scaling past PostgreSQL
 
-At the upper end of the sizing guide, operating PostgreSQL at cyoda-go's
-write volume becomes the bottleneck. That is where the Cassandra backend
-(today via Cyoda Cloud) makes sense. See
-[Cyoda Cloud](./cyoda-cloud/).
+At the upper end of the sizing guide, PostgreSQL's write throughput
+becomes the bottleneck. Two paths past it — the application contract
+is identical in both:
+
+- **Swap to the commercial Cassandra storage engine, still on
+  Kubernetes.** The licensable plugin replaces the PostgreSQL backend
+  with a horizontally-scaling Cassandra-backed tier. The Helm chart,
+  the pod topology, and the application code are unchanged — only the
+  storage plugin configuration changes.
+- **Hand operations to Cyoda Cloud.** A SaaS that runs either the
+  PostgreSQL or Cassandra stack for you. Same application contract,
+  different operational model.
+
+See [Cyoda Cloud](./cyoda-cloud/) for the SaaS option; contact sales
+for the commercial Cassandra plugin.

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -24,6 +24,37 @@
   background-color: transparent;
 }
 
+/* Starlight asides (note / tip / caution / danger) — desaturated
+ * Cyoda-adjacent palette. Starlight's defaults use vivid lavender /
+ * neon-tip purple that clashes with the Cyoda voice; we re-tint to
+ * muted teal (tip), muted orange (caution), desaturated red (danger),
+ * and cool grey (note). Title/icon colours are a darker variant of
+ * the border hue so they hit WCAG AA on the pale background.
+ *
+ * Unlayered overrides beat Starlight's @layer starlight.components
+ * rules, so no !important needed.
+ */
+.starlight-aside--note {
+  --sl-color-asides-text-accent: hsl(220 10% 35%);
+  --sl-color-asides-border: hsl(220 10% 55%);
+  background-color: hsl(220 10% 55% / 0.06);
+}
+.starlight-aside--tip {
+  --sl-color-asides-text-accent: hsl(175 40% 32%);
+  --sl-color-asides-border: hsl(175 40% 50%);
+  background-color: hsl(175 40% 50% / 0.08);
+}
+.starlight-aside--caution {
+  --sl-color-asides-text-accent: hsl(33 55% 38%);
+  --sl-color-asides-border: hsl(33 55% 55%);
+  background-color: hsl(33 55% 55% / 0.10);
+}
+.starlight-aside--danger {
+  --sl-color-asides-text-accent: hsl(0 50% 40%);
+  --sl-color-asides-border: hsl(0 55% 55%);
+  background-color: hsl(0 55% 55% / 0.08);
+}
+
 /* UI-screenshot images — cap at 600px wide, natural aspect preserved.
  * Pair with `class="screenshot"` on an Astro <Image /> tag in MDX.
  * Prevents life-size banner rendering of app screenshots when the

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -37,8 +37,20 @@
 .sl-markdown-content .expressive-code {
   --ec-frm-trmTtbBg: var(--cyoda-aqua-light);
   --ec-frm-edTabBarBg: var(--cyoda-aqua-light);
-  --ec-frm-trmTtbBrdBtmCol: var(--cyoda-aqua-medium);
+  --ec-frm-trmTtbBrdBtmCol: transparent;
   --ec-brdCol: var(--cyoda-aqua-medium);
+}
+
+/* When expressive-code renders a chromed frame (terminal three-dots
+ * header, or an editor tab bar), drop our own pre border / border-
+ * radius / border-left so the panel reads as one unified frame
+ * rather than frame-within-frame. The outer EC frame provides the
+ * rounded border; inner pre sits flush. */
+.sl-markdown-content .expressive-code .frame.is-terminal pre,
+.sl-markdown-content .expressive-code .frame.has-title pre {
+  border: none;
+  border-left: none;
+  border-radius: 0;
 }
 
 /* Starlight asides (note / tip / caution / danger) — desaturated

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -24,33 +24,43 @@
   background-color: transparent;
 }
 
-/* Expressive-code code panels — tint the chrome so terminal/editor
- * frames read as a single unified Cyoda-aqua panel instead of
- * grey-chrome-over-teal-code.
+/* Code panels — clean and minimal.
  *
- * The body of the pre is already tinted via `.sl-markdown-content pre`
- * (cyoda-aqua-light). Expressive-code's terminal title bar and editor
- * tab bar default to `--sl-color-gray-6`, producing a two-tone look.
- * Override the three EC variables that paint the chrome + its bottom
- * divider so the frame unifies.
+ * Hide expressive-code's decorative chrome (macOS-style three dots
+ * on `is-terminal` blocks, tab-style header on `has-title` blocks).
+ * Keep just what matters: a thin Cyoda-aqua border around the pre,
+ * a small language label in the top-left (read from
+ * `pre[data-language]`), the copy button in the top-right (EC-
+ * provided), and syntax-highlighted code in between.
  */
-.sl-markdown-content .expressive-code {
-  --ec-frm-trmTtbBg: var(--cyoda-aqua-light);
-  --ec-frm-edTabBarBg: var(--cyoda-aqua-light);
-  --ec-frm-trmTtbBrdBtmCol: transparent;
-  --ec-brdCol: var(--cyoda-aqua-medium);
+.sl-markdown-content .expressive-code .frame.is-terminal .header,
+.sl-markdown-content .expressive-code .frame.has-title .header {
+  display: none;
 }
 
-/* When expressive-code renders a chromed frame (terminal three-dots
- * header, or an editor tab bar), drop our own pre border / border-
- * radius / border-left so the panel reads as one unified frame
- * rather than frame-within-frame. The outer EC frame provides the
- * rounded border; inner pre sits flush. */
-.sl-markdown-content .expressive-code .frame.is-terminal pre,
-.sl-markdown-content .expressive-code .frame.has-title pre {
-  border: none;
-  border-left: none;
-  border-radius: 0;
+.sl-markdown-content .expressive-code .frame {
+  position: relative;
+}
+
+.sl-markdown-content .expressive-code .frame pre {
+  border: 1px solid var(--cyoda-aqua-medium);
+  border-radius: 6px;
+  padding-top: 1.75rem;
+}
+
+.sl-markdown-content .expressive-code .frame pre::before {
+  content: attr(data-language);
+  position: absolute;
+  top: 0.4rem;
+  left: 0.75rem;
+  font-size: 0.7rem;
+  font-family: var(--__sl-font-mono, ui-monospace, monospace);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: hsl(var(--cyoda-teal) / 0.75);
+  font-weight: 600;
+  pointer-events: none;
+  z-index: 1;
 }
 
 /* Starlight asides (note / tip / caution / danger) — desaturated

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -58,7 +58,6 @@
 }
 
 .footer-links a:hover {
-  text-decoration: underline;
   border-bottom: 2px solid var(--cyoda-aqua);
 }
 
@@ -76,7 +75,6 @@
 }
 
 .footer-link-button:hover {
-  text-decoration: underline;
   border-bottom: 2px solid var(--cyoda-aqua);
 }
 

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -24,6 +24,17 @@
   background-color: transparent;
 }
 
+/* UI-screenshot images — cap at 600px wide, natural aspect preserved.
+ * Pair with `class="screenshot"` on an Astro <Image /> tag in MDX.
+ * Prevents life-size banner rendering of app screenshots when the
+ * content column is wider than the screenshot makes sense to be. */
+.sl-markdown-content img.screenshot {
+  max-width: 600px;
+  height: auto;
+  /* min-height from img[loading="lazy"] doesn't help narrow screenshots */
+  min-height: 0;
+}
+
 /* Footer styling */
 .footer {
   border-top: 1px solid var(--cyoda-aqua-medium);

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -24,6 +24,23 @@
   background-color: transparent;
 }
 
+/* Expressive-code code panels — tint the chrome so terminal/editor
+ * frames read as a single unified Cyoda-aqua panel instead of
+ * grey-chrome-over-teal-code.
+ *
+ * The body of the pre is already tinted via `.sl-markdown-content pre`
+ * (cyoda-aqua-light). Expressive-code's terminal title bar and editor
+ * tab bar default to `--sl-color-gray-6`, producing a two-tone look.
+ * Override the three EC variables that paint the chrome + its bottom
+ * divider so the frame unifies.
+ */
+.sl-markdown-content .expressive-code {
+  --ec-frm-trmTtbBg: var(--cyoda-aqua-light);
+  --ec-frm-edTabBarBg: var(--cyoda-aqua-light);
+  --ec-frm-trmTtbBrdBtmCol: var(--cyoda-aqua-medium);
+  --ec-brdCol: var(--cyoda-aqua-medium);
+}
+
 /* Starlight asides (note / tip / caution / danger) — desaturated
  * Cyoda-adjacent palette. Starlight's defaults use vivid lavender /
  * neon-tip purple that clashes with the Cyoda voice; we re-tint to

--- a/src/styles/visual.css
+++ b/src/styles/visual.css
@@ -44,6 +44,24 @@
   margin-block-end: 2rem;
 }
 
+/* Tighten the vertical rhythm inside the hero.
+ *
+ * Starlight's default h1 margin-top is ~4rem which leaves a gaping
+ * void between the badge and the heading. And the buttons have no
+ * default margin at all, so they collide with the paragraph above.
+ * Re-balance so the flow is: badge -> heading -> paragraph -> buttons
+ * with consistent 1-1.25rem gaps.
+ */
+.section-hero .sl-heading-wrapper {
+  margin-top: 1.25rem;
+}
+.section-hero .cyoda-btn {
+  margin-top: 1.25rem;
+}
+.section-hero .cyoda-btn + .cyoda-btn {
+  margin-left: 0.5rem;
+}
+
 /* Dotted divider */
 .section-separator {
   height: 1rem;


### PR DESCRIPTION
## Summary

What started as a CTA-button border fix grew into a small landing-page polish pass plus several site-wide visual corrections surfaced by smoke-testing. 17 commits, scoped to styles and landing-page content.

## Landing page (`src/content/docs/index.mdx`)

- **Hero copy rewrite** (`6c9440e`, `0222fd1`) — triangulated via two fresh-context senior-engineer evaluations and iterated against `cyoda-launchpad.pages.dev/#how-it-works`. Replaces "Developer platform · digital twins" + "Build once. Run anywhere on the growth path." with:
  - Badge: **EDBMS — Entity Database Management System**
  - Heading: **One transactional runtime for the entity lifecycle.**
  - Body: "Cyoda is an EDBMS: state machine, processors, and full revision history live inside the record, committed atomically — minimizing the need for sagas. A simpler stack than Postgres + Temporal + Kafka + a CDC audit pipeline. Build complete event-driven backends on one runtime. Open source, single Go binary, Postgres-backed."
- **Hero vertical rhythm** (`6868d55`) — tightened gaps (badge → heading was 63px, now 20px; paragraph → buttons was 0px, now 20px).
- **CTA buttons** (`5e21868`) — fixed the "bottom border partially hidden" bug caused by `.sl-markdown-content a` in `public/styles/non-critical.css` defeating Astro's scoped `:where()` button border; shrank buttons from 46px → 38px tall.
- **Growth-path diagram intro** (`0c3f679`) — added the "Four storage engines. One application contract." heading + short intro naming the three OSS engines and the commercial Cassandra plugin.
- **"Where to go next" links** (`5810145`) — each tier (desktop, Docker, Kubernetes, Cyoda Cloud) and the `cyoda-go` repo are now linked inline, not just named.

## Site-wide styling

- **Body-text links** (`58504bd`, `76d09d7`, `f864a4c`) — fixed a multi-layered bug:
  - `--cyoda-purple` was defined in two files with different formats (hex in `non-critical.css`, HSL components in `tokens.css`); the HSL-components definition won, so `color: var(--cyoda-purple)` resolved to an invalid CSS value and Starlight's default near-black accent took over. Wrapped in `hsl(...)`.
  - Bumped selector specificity to `a[href]:not(.cyoda-btn):not(.sl-anchor-link)` to beat Starlight's layered rule and to exclude heading anchor icons (whose own `::after` was being stretched by our arrow content).
  - Default state now shows aqua text + trailing `→` arrow (non-breaking space attached); underline appears on hover.
  - Footer double-underline on hover de-duplicated (`text-decoration: underline` + `border-bottom` → just border-bottom).
- **Aside (admonition) palette** (`839f6e5`) — desaturated, on-brand:
  - note: cool grey
  - tip: muted teal (previously Starlight's pale lavender)
  - caution: muted orange
  - danger: desaturated red
- **Code panels** (`95e127b` supersedes `8d0ad40`, `49cc18a`) — hide expressive-code's decorative chrome (macOS three dots, tab bar); show a small uppercase language label top-left (from `pre[data-language]`); keep EC's copy button top-right; thin Cyoda-aqua border + rounded corners. Industry-standard look.

## `/run/` content corrections

- **`run/kubernetes.md`** (`4fb39ee`) — the "When you outgrow Kubernetes" section wrongly implied Kubernetes stops being viable at high volume and Cyoda Cloud is the next step. Rewrote as "Scaling past PostgreSQL": two paths — (1) swap to the commercial Cassandra storage engine (still on Kubernetes), (2) hand operations to Cyoda Cloud (SaaS over either backend). Application contract is identical in both. Added a matching note under "Deployment shape" that the stateful backend is pluggable.
- **`run/desktop.md` and `run/docker.md`** (`55d786a`) — dropped the "When you outgrow…" sections entirely. Cheap advertising: readers already know Docker images compose with anything, and the factual desktop-tier constraints live inline earlier in the page.

## `/run/cyoda-cloud/provisioning/` screenshots

- **Size + aspect** (`143f570`, `232c3a2`) — the 8 UI screenshots rendered at their declared 800px intrinsic width (life-sized dialogs). Added `class="screenshot"` → `max-width: 600px; height: auto` in `custom.css`. First attempt declared `width={600} height={450}` which made Astro crop each variant to 4:3 and lose content (the "Q" of "Quick Start" went missing). Second fix dropped the dimensions entirely so Astro uses natural aspect ratios.

## Build-fix footnote

- **`astro.config.mjs`** (already merged into `feature/cyoda-go-init` via PR #72, commit `173a803`) — the `vite.build.rollupOptions.treeshake.moduleSideEffects: false` removal that fixed Starlight's CSS-only side-effect imports is what surfaced the expressive-code chrome regression this PR now addresses.

## Verification

- `ASTRO_TELEMETRY_DISABLED=1 npm run build` — clean, 109 pages.
- `npx playwright test tests/link-integrity.spec.ts` — 5/5 pass.
- Visual verification on every change via Playwright MCP on localhost preview, and on the live surge preview at https://cyoda-docs-docs-landing-page-button-fix.surge.sh/

## Base

Targets `feature/cyoda-go-init`, not `main`.