### PR TITLE
chore: gitignore .playwright-mcp/ (stop stray screenshots in repo root)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,13 @@ pnpm-debug.log*
 test-results/
 playwright-report/
 
+# Playwright MCP session artefacts + screenshots.
+# The MCP is configured with `--output-dir .playwright-mcp` (via the
+# Claude CLI `claude mcp` config) so page snapshots, console logs,
+# and any screenshots Claude asks it to take land here — not at the
+# repo root. This ignore keeps the directory out of git regardless
+# of whether the --output-dir flag is set on a given host/worktree.
+.playwright-mcp/
+
 # agent-safehouse local settings
 .sandbox/


### PR DESCRIPTION
## Problem

Every session with the Playwright MCP ends with a pile of untracked PNG screenshots at the repo root (25–30 per working session). They're harmless but noisy; they fill `git status`, get accidentally grepped, and have to be manually deleted.

## Fix

Two coordinated changes:

1. **MCP config (machine-local, not in this PR):** run
   ```
   claude mcp remove playwright -s local
   claude mcp add playwright --scope local -- npx @playwright/mcp@latest --output-dir .playwright-mcp
   ```
   This tells Playwright MCP to write session artefacts and screenshots under `.playwright-mcp/` instead of CWD.

2. **This PR:** add `.playwright-mcp/` to `.gitignore` so anything the MCP writes there — page snapshots (`page-*.yml`), console logs (`console-*.log`), and screenshots — stays out of git regardless of whether the `--output-dir` flag is set on a given host/worktree.

Belt-and-braces: the config change stops the problem at source; the gitignore catches it if the config drifts.

## Verification

```
$ git check-ignore -v .playwright-mcp/test.png
.gitignore:43:.playwright-mcp/   .playwright-mcp/test.png
```

## Base

Targets `feature/cyoda-go-init` per the established convention.