### PR TITLE
ci: split deploy.yml from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+# Build and test on every PR targeting main. No deploy.
+name: CI
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci --omit=dev
+      - name: Install Playwright browsers for Mermaid rendering and testing
+        run: npx playwright install --with-deps chromium
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: false
+          CI: true
+      - name: Build site
+        run: npm run build
+        env:
+          NODE_ENV: production
+          GA_MEASUREMENT_ID: ${{ secrets.GA_MEASUREMENT_ID }}
+          CI: true
+      - name: Install serve for testing
+        run: npm install -g serve
+      - name: Run node:test + Playwright (GDPR, GA, navigators, build integration)
+        run: npm test
+        env:
+          NODE_ENV: production
+          GA_MEASUREMENT_ID: ${{ secrets.GA_MEASUREMENT_ID }}
+          CI: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,10 @@
-# Build and deploy Astro site to GitHub Pages
+# Build, test, and deploy the site to GitHub Pages.
+# Runs only on push to main and manual dispatch — PR checks live in ci.yml.
 name: Deploy Astro site to Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
-
-  # Runs build + tests on every PR targeting main (deploy job is gated below)
-  pull_request:
-    branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -66,8 +60,6 @@ jobs:
           path: dist/
 
   deploy:
-    # Only deploy on actual merges / manual dispatches — never from a PR
-    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

Two focused workflow files instead of one unified \`static.yml\`:

- \`ci.yml\` — fires on \`pull_request: branches: [main]\`, runs **build + tests** only. Job name \`build\` (matches the required status-check name in branch protection).
- \`deploy.yml\` — renamed from \`static.yml\`, fires on \`push: branches: [main]\` and \`workflow_dispatch\`, runs **build + tests + deploy**. Drops the \`pull_request\` trigger and the \`if: github.event_name != 'pull_request'\` gate (both now redundant).

## Why

The unified static.yml showed up as \"Deploy Astro site to Pages\" in the PR Checks UI on every PR, even though the deploy job was correctly skipped. Visually confusing. Split gives each workflow a single job.

## Test plan

- [x] Both YAML files validate
- [ ] This PR fires ci.yml (build + test), does NOT fire deploy.yml
- [ ] On merge, main's push fires deploy.yml (build + test + deploy to Pages)

## Related

Follow-up from PR #76 team feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)