### PR TITLE
docs: point readers at cyoda-skills plugin

### DIFF
--- a/docs/superpowers/plans/2026-05-04-cyoda-skills-pointer.md
+++ b/docs/superpowers/plans/2026-05-04-cyoda-skills-pointer.md
@@ -1,0 +1,168 @@
+# Cyoda Skills Pointer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a lead paragraph on `build/index.mdx` and `getting-started/install-and-first-entity.mdx` pointing readers at the cyoda-skills Claude Code plugin as the recommended first step.
+
+**Architecture:** Content-only edits. Two prose paragraphs inserted at the top of two existing MDX pages. No new components, no new dependencies, no sidebar changes. Both link to `https://github.com/Cyoda-platform/cyoda-skills`.
+
+**Tech Stack:** Astro + Starlight (MDX). No code; verification is a successful `npm run build:only` and a visual check via `npm run dev`.
+
+**Spec:** `docs/superpowers/specs/2026-05-04-cyoda-skills-pointer-design.md`
+
+---
+
+## File Structure
+
+- Modify: `src/content/docs/build/index.mdx` — insert lead paragraph above existing intro.
+- Modify: `src/content/docs/getting-started/install-and-first-entity.mdx` — insert lead paragraph above existing intro, before `## Install`.
+
+No tests are added; this is content-only and the existing Playwright suite is unaffected.
+
+---
+
+### Task 1: Add lead paragraph to Build landing page
+
+**Files:**
+- Modify: `src/content/docs/build/index.mdx` (insert between frontmatter and existing intro paragraph at line 8)
+
+- [ ] **Step 1: Read the current file**
+
+Run: `cat src/content/docs/build/index.mdx`
+
+Expected: file starts with frontmatter (lines 1–6), blank line (7), then existing intro paragraph beginning "Cyoda applications are **digital twins**…" at line 8.
+
+- [ ] **Step 2: Insert the lead paragraph**
+
+Use Edit to replace the existing block:
+
+```
+---
+title: Build
+description: Develop Cyoda applications — tier-agnostic patterns that work on any runtime.
+sidebar:
+  order: 0
+---
+
+Cyoda applications are **digital twins**: the same code runs on every
+```
+
+with:
+
+```
+---
+title: Build
+description: Develop Cyoda applications — tier-agnostic patterns that work on any runtime.
+sidebar:
+  order: 0
+---
+
+Building with Cyoda is easiest with an AI coding assistant. The [Cyoda
+Skills plugin](https://github.com/Cyoda-platform/cyoda-skills) drops in
+to Claude Code, Cursor, Codex, and other compatible tools, giving them
+the skills to set up a local instance, model entities, design
+workflows, and run tests against your Cyoda app. Install it from
+[github.com/Cyoda-platform/cyoda-skills](https://github.com/Cyoda-platform/cyoda-skills)
+and let your assistant lead — the rest of this section is the manual
+reference behind what the skills do.
+
+Cyoda applications are **digital twins**: the same code runs on every
+```
+
+- [ ] **Step 3: Verify the build still passes**
+
+Run: `npm run build:only`
+Expected: build completes without errors. The MDX page renders.
+
+- [ ] **Step 4: Visual check**
+
+Run: `npm run dev` (in a separate terminal, or background it)
+Open: `http://localhost:4321/build/`
+Expected: the new paragraph is the first thing on the page, above the "digital twins" paragraph. Both `Cyoda Skills plugin` and `github.com/Cyoda-platform/cyoda-skills` link to `https://github.com/Cyoda-platform/cyoda-skills`. Stop the dev server.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/content/docs/build/index.mdx
+git commit -m "docs(build): point readers at cyoda-skills plugin
+
+Add a lead paragraph on the Build landing page recommending the
+cyoda-skills Claude Code plugin as the first stop for anyone building
+on Cyoda. No install instructions or per-skill reference — the
+plugin's GitHub README is the source of truth."
+```
+
+---
+
+### Task 2: Add lead paragraph to Getting Started page
+
+**Files:**
+- Modify: `src/content/docs/getting-started/install-and-first-entity.mdx` (insert between the imports block and the existing intro paragraph at line 11)
+
+- [ ] **Step 1: Read the current file**
+
+Run: `head -20 src/content/docs/getting-started/install-and-first-entity.mdx`
+
+Expected: frontmatter (lines 1–6), imports (lines 7–9), blank line (10), existing intro paragraph beginning "This page takes you from nothing installed…" at line 11.
+
+- [ ] **Step 2: Insert the lead paragraph**
+
+Use Edit to replace the existing block:
+
+```
+import { Aside } from '@astrojs/starlight/components';
+import FromTheBinary from '../../../components/FromTheBinary.astro';
+
+This page takes you from nothing installed to a persisted entity you can query,
+```
+
+with:
+
+```
+import { Aside } from '@astrojs/starlight/components';
+import FromTheBinary from '../../../components/FromTheBinary.astro';
+
+Building with Cyoda is easiest with an AI coding assistant. The [Cyoda
+Skills plugin](https://github.com/Cyoda-platform/cyoda-skills) drops in
+to Claude Code, Cursor, Codex, and other compatible tools, giving them
+the skills to set up a local instance, model entities, design
+workflows, and run tests against your Cyoda app. Install it from
+[github.com/Cyoda-platform/cyoda-skills](https://github.com/Cyoda-platform/cyoda-skills)
+and let your assistant lead — the rest of this page walks through the
+same steps by hand.
+
+This page takes you from nothing installed to a persisted entity you can query,
+```
+
+Note the closing clause differs from Task 1: "the rest of this **page walks through the same steps by hand**" (vs Task 1's "the rest of this **section is the manual reference behind what the skills do**"). This is intentional — the surrounding context differs.
+
+- [ ] **Step 3: Verify the build still passes**
+
+Run: `npm run build:only`
+Expected: build completes without errors.
+
+- [ ] **Step 4: Visual check**
+
+Run: `npm run dev`
+Open: `http://localhost:4321/getting-started/install-and-first-entity/`
+Expected: the new paragraph appears at the top of the page, above the existing "This page takes you from nothing installed…" intro and above the `## Install` heading. Both links point to `https://github.com/Cyoda-platform/cyoda-skills`. Stop the dev server.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/content/docs/getting-started/install-and-first-entity.mdx
+git commit -m "docs(getting-started): point readers at cyoda-skills plugin
+
+Add a lead paragraph on the install/first-entity page recommending
+the cyoda-skills Claude Code plugin as the easiest path. The manual
+walkthrough below remains the reference for users not driving via an
+AI assistant."
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage.** Spec calls for: (1) lead paragraph on `build/index.mdx` — Task 1. (2) lead paragraph on `getting-started/install-and-first-entity.mdx` — Task 2. (3) link target `https://github.com/Cyoda-platform/cyoda-skills` — used in both. (4) verification via `npm run build:only` + `npm run dev` — Step 3 and Step 4 in both tasks. No gaps.
+- **Placeholders.** None — both paragraphs are written verbatim, both commit messages are written verbatim, all commands are concrete.
+- **Type consistency.** N/A — no code, no types. Wording differs between the two pages by exactly one closing clause; this is called out explicitly in Task 2 Step 2.

--- a/docs/superpowers/specs/2026-05-04-cyoda-skills-pointer-design.md
+++ b/docs/superpowers/specs/2026-05-04-cyoda-skills-pointer-design.md
@@ -1,0 +1,115 @@
+# Cyoda Skills pointer in cyoda-docs
+
+**Status:** Proposed
+**Date:** 2026-05-04
+
+## Problem
+
+The [cyoda-skills](https://github.com/Cyoda-platform/cyoda-skills)
+Claude Code plugin is the recommended first stop for anyone building
+on Cyoda — it bundles skills (`/cyoda:setup`, `/cyoda:build`,
+`/cyoda:design`, `/cyoda:test`, …) that automate setup, entity
+modeling, workflow design, and testing against a Cyoda instance. The
+docs site currently makes no mention of it, so readers landing in
+**Build** or **Getting Started** miss the easiest path and start with
+the manual reference instead.
+
+The skills themselves already reference cyoda-docs and the cyoda-go
+help feature for content. Mirroring install steps or per-skill
+descriptions in cyoda-docs would be circular and would rot. The fix is
+a small pointer, not a parallel reference.
+
+## Goal
+
+Direct readers starting to build on Cyoda to the cyoda-skills plugin
+as the recommended first step, while keeping cyoda-docs free of any
+content that duplicates what the plugin (or its README) already owns.
+
+## Non-goals
+
+- No dedicated page for the plugin in cyoda-docs (e.g. no
+  `build/cyoda-skills.mdx`).
+- No install instructions for any tool (Claude Code, Cursor, Codex,
+  …) — the plugin's GitHub README is the source of truth.
+- No enumeration or per-skill reference for `/cyoda:setup`,
+  `/cyoda:build`, etc.
+- No restructure of the existing Build pages or Getting Started page
+  beyond inserting one lead paragraph at the top.
+- No new sidebar entry.
+
+## Design
+
+### Placement
+
+Two insertions, both lead paragraphs at the very top of the page body
+(above all existing content, including any current intro paragraph and
+the first heading):
+
+1. `src/content/docs/build/index.mdx` — above the existing intro about
+   digital twins and the "Where to next" list.
+2. `src/content/docs/getting-started/install-and-first-entity.mdx` —
+   above the existing intro paragraph and the `## Install` heading.
+
+### Form
+
+Plain prose paragraph. No Starlight `<Aside>`, no `<LinkCard>`, no
+heading — the recommendation reads as native page voice and is the
+first thing the reader sees.
+
+### Content
+
+A single paragraph, used on both pages with a one-clause tweak per
+context.
+
+**On `build/index.mdx`:**
+
+> Building with Cyoda is easiest with an AI coding assistant. The
+> [Cyoda Skills plugin](https://github.com/Cyoda-platform/cyoda-skills)
+> drops in to Claude Code, Cursor, Codex, and other compatible tools,
+> giving them the skills to set up a local instance, model entities,
+> design workflows, and run tests against your Cyoda app. Install it
+> from
+> [github.com/Cyoda-platform/cyoda-skills](https://github.com/Cyoda-platform/cyoda-skills)
+> and let your assistant lead — the rest of this section is the manual
+> reference behind what the skills do.
+
+**On `getting-started/install-and-first-entity.mdx`:**
+
+Same paragraph, but the closing clause changes to:
+
+> …the rest of this page walks through the same steps by hand.
+
+### Link target
+
+All links point at the repository root,
+`https://github.com/Cyoda-platform/cyoda-skills`. The repo's README is
+expected to carry install instructions and the skill list. If a
+dedicated landing page is later published (e.g. on cyoda.com), only
+this URL needs to change.
+
+## Out of scope
+
+See **Non-goals** above. In particular, the plugin's install steps and
+skill catalogue are intentionally not mirrored here.
+
+## Verification
+
+Content-only change. Verification is:
+
+- `npm run build:only` completes without errors.
+- `npm run dev` — visit `/build/` and
+  `/getting-started/install-and-first-entity/` and confirm the lead
+  paragraph renders at the top of each page with a working link to the
+  GitHub repo.
+
+No new tests; existing Playwright suite is unaffected.
+
+## Risks
+
+- **Repo URL changes.** Mitigated by linking to a single canonical URL
+  in two places — easy to find and update.
+- **Plugin scope drifts** (skills are renamed, new ones added). The
+  paragraph deliberately describes capabilities ("set up a local
+  instance, model entities, design workflows, run tests") rather than
+  naming individual skills, so it stays accurate without coupling to
+  the plugin's command names.

--- a/src/content/docs/build/index.mdx
+++ b/src/content/docs/build/index.mdx
@@ -5,6 +5,15 @@ sidebar:
   order: 0
 ---
 
+Building with Cyoda is easiest with an AI coding assistant. The [Cyoda
+Skills plugin](https://github.com/Cyoda-platform/cyoda-skills) drops in
+to Claude Code, Cursor, Codex, and other compatible tools, giving them
+the skills to set up a local instance, model entities, design
+workflows, and run tests against your Cyoda app. Install it from
+[github.com/Cyoda-platform/cyoda-skills](https://github.com/Cyoda-platform/cyoda-skills)
+and let your assistant lead — the rest of this section is the manual
+reference behind what the skills do.
+
 Cyoda applications are **digital twins**: the same code runs on every
 storage tier, from in-memory dev through Cassandra at enterprise
 scale. Pages in this section cover the patterns — entity modeling,

--- a/src/content/docs/build/index.mdx
+++ b/src/content/docs/build/index.mdx
@@ -5,20 +5,21 @@ sidebar:
   order: 0
 ---
 
-Building with Cyoda is easiest with an AI coding assistant. The [Cyoda
-Skills plugin](https://github.com/Cyoda-platform/cyoda-skills) drops in
-to Claude Code, Cursor, Codex, and other compatible tools, giving them
-the skills to set up a local instance, model entities, design
-workflows, and run tests against your Cyoda app. Install it from
-[github.com/Cyoda-platform/cyoda-skills](https://github.com/Cyoda-platform/cyoda-skills)
-and let your assistant lead — the rest of this section is the manual
-reference behind what the skills do.
-
 Cyoda applications are **digital twins**: the same code runs on every
 storage tier, from in-memory dev through Cassandra at enterprise
 scale. Pages in this section cover the patterns — entity modeling,
 workflows, external processors, testing — independent of where your
 app runs.
+
+## Build with a coding agent
+
+Building with Cyoda is easiest with an AI coding assistant. The <a href="https://github.com/Cyoda-platform/cyoda-skills" target="_blank" rel="noopener noreferrer">Cyoda Skills plugin</a> drops in
+to Claude Code, Cursor, Codex, and other compatible tools, giving them
+the skills to set up a local instance, model entities, design
+workflows, and run tests against your Cyoda app. Install it from
+<a href="https://github.com/Cyoda-platform/cyoda-skills" target="_blank" rel="noopener noreferrer">github.com/Cyoda-platform/cyoda-skills</a>
+and let your assistant lead — the rest of this section is the manual
+reference behind what the skills do.
 
 Where to next:
 

--- a/src/content/docs/getting-started/install-and-first-entity.mdx
+++ b/src/content/docs/getting-started/install-and-first-entity.mdx
@@ -8,6 +8,15 @@ sidebar:
 import { Aside } from '@astrojs/starlight/components';
 import FromTheBinary from '../../../components/FromTheBinary.astro';
 
+Building with Cyoda is easiest with an AI coding assistant. The [Cyoda
+Skills plugin](https://github.com/Cyoda-platform/cyoda-skills) drops in
+to Claude Code, Cursor, Codex, and other compatible tools, giving them
+the skills to set up a local instance, model entities, design
+workflows, and run tests against your Cyoda app. Install it from
+[github.com/Cyoda-platform/cyoda-skills](https://github.com/Cyoda-platform/cyoda-skills)
+and let your assistant lead — the rest of this page walks through the
+same steps by hand.
+
 This page takes you from nothing installed to a persisted entity you can query,
 running entirely on your own machine. The default backend is **SQLite** — zero
 operational overhead, one file on disk, data survives restarts.

--- a/src/content/docs/getting-started/install-and-first-entity.mdx
+++ b/src/content/docs/getting-started/install-and-first-entity.mdx
@@ -8,20 +8,11 @@ sidebar:
 import { Aside } from '@astrojs/starlight/components';
 import FromTheBinary from '../../../components/FromTheBinary.astro';
 
-Building with Cyoda is easiest with an AI coding assistant. The [Cyoda
-Skills plugin](https://github.com/Cyoda-platform/cyoda-skills) drops in
-to Claude Code, Cursor, Codex, and other compatible tools, giving them
-the skills to set up a local instance, model entities, design
-workflows, and run tests against your Cyoda app. Install it from
-[github.com/Cyoda-platform/cyoda-skills](https://github.com/Cyoda-platform/cyoda-skills)
-and let your assistant lead — the rest of this page walks through the
-same steps by hand.
-
 This page takes you from nothing installed to a persisted entity you can query,
 running entirely on your own machine. The default backend is **SQLite** — zero
 operational overhead, one file on disk, data survives restarts.
 
-## Install
+## Install Cyoda
 
 cyoda-go ships as a single binary. Pick the flavour that fits your machine; the
 authoritative list of installers lives in the
@@ -39,6 +30,16 @@ If it didn't (or if you installed another way), run `cyoda init` yourself — se
 packages, and Fedora RPMs are available for other environments.
 
 <FromTheBinary topic="cli init" />
+
+## Install Cyoda coding agent skills
+
+Building with Cyoda is easiest with an AI coding assistant. The <a href="https://github.com/Cyoda-platform/cyoda-skills" target="_blank" rel="noopener noreferrer">Cyoda Skills plugin</a> drops in
+to Claude Code, Cursor, Codex, and other compatible tools, giving them
+the skills to set up a local instance, model entities, design
+workflows, and run tests against your Cyoda app. Install it from
+<a href="https://github.com/Cyoda-platform/cyoda-skills" target="_blank" rel="noopener noreferrer">github.com/Cyoda-platform/cyoda-skills</a>
+and let your assistant lead — the rest of this page walks through the
+same steps by hand.
 
 ## Why SQLite is the default
 


### PR DESCRIPTION
## Summary
- Adds a "Build with a coding agent" section on `build/index.mdx` pointing at the [cyoda-skills](https://github.com/Cyoda-platform/cyoda-skills) Claude Code plugin.
- Adds an "Install Cyoda coding agent skills" section on `getting-started/install-and-first-entity.mdx`, and renames the prior "Install" heading to "Install Cyoda".
- External links to the plugin repo open in new tabs.
- No install instructions or per-skill reference here — the plugin's GitHub README is the source of truth, and the skills themselves reference cyoda-docs.

Spec: `docs/superpowers/specs/2026-05-04-cyoda-skills-pointer-design.md`
Plan: `docs/superpowers/plans/2026-05-04-cyoda-skills-pointer.md`

## Test plan
- [x] `npm run build:only` passes (237 pages)
- [x] `npm test` passes (54 node + 142 Playwright)
- [ ] Reviewer visually confirms `/build/` and `/getting-started/install-and-first-entity/` render the new sections and that the links open in new tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)