### PR TITLE
docs: document v0.8.1 features — OIDC/IAM, grouped stats, workflow annotations

### DIFF
--- a/src/content/docs/build/searching-entities.mdx
+++ b/src/content/docs/build/searching-entities.mdx
@@ -15,7 +15,9 @@ goes beyond a single id lookup, or when you want to scope by workflow
 state. For single-entity reads, stay on the CRUD endpoints in
 [working with entities](/build/working-with-entities/); for cross-entity
 analytics, use [SQL](/build/analytics-with-sql/); for event-driven
-compute, use [gRPC compute nodes](/build/client-compute-nodes/).
+compute, use [gRPC compute nodes](/build/client-compute-nodes/). For
+counts and aggregates without the entity bodies, jump to
+[grouped statistics](#grouped-statistics).
 
 ## Two query modes
 
@@ -167,6 +169,90 @@ form, see [`point_time` in analytics](/build/analytics-with-sql/).
   cheaper per entity than a series of `direct` pages.
 - Avoid open-ended `pointInTime` scans across every revision — anchor
   the query at a specific timestamp or a short window.
+
+## Grouped statistics
+
+When you want **counts and aggregates** rather than the entities
+themselves — *how many orders are in each state? what is the total
+amount per country?* — use the grouped-statistics query instead of
+paging a search result and summing client-side. It returns one row per
+group and never the underlying entity bodies, so it stays cheap over
+large populations.
+
+```http
+POST /entity/stats/{entityName}/{modelVersion}/query
+```
+
+```bash
+curl -X POST http://localhost:8080/api/entity/stats/orders/1/query \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "groupBy": ["state", "$.country"],
+    "aggregations": [
+      { "op": "sum", "field": "$.amount", "as": "totalAmount" },
+      { "op": "avg", "field": "$.amount" }
+    ],
+    "condition": {
+      "type": "simple",
+      "jsonPath": "$.channel",
+      "operation": "EQUALS",
+      "value": "web"
+    }
+  }'
+```
+
+The request has four parts:
+
+- **`groupBy`** (required) — an ordered list of dimensions. Each entry is
+  either the literal `state` (the workflow state) or a `$.`-prefixed
+  JSONPath into the entity payload. The result `groupKey` is ordered to
+  match.
+- **`aggregations`** (optional) — per-group numeric aggregates. Each is
+  `{ "op", "field", "as" }` where `op` is one of `sum`, `avg`, `min`,
+  `max`, `stdev`, `field` is a JSONPath, and `as` is an optional alias
+  (defaults to `op(field)`, e.g. `sum($.amount)`). Every group also
+  carries a `count` whether or not you request aggregations.
+- **`condition`** (optional) — a predicate that restricts the population,
+  using the **same** [Condition DSL](#filter-shape) as search.
+- **`limit`** (optional) — caps the number of buckets returned; must be
+  ≤ the server's `CYODA_STATS_GROUP_MAX` (default 10000).
+
+The response is one bucket per group:
+
+```json
+[
+  {
+    "groupKey": [
+      { "field": "state", "value": "submitted" },
+      { "field": "$.country", "value": "GB" }
+    ],
+    "count": 31,
+    "aggregations": { "totalAmount": 48210.0, "avg($.amount)": 1555.16 }
+  }
+]
+```
+
+Aggregation values are numeric, or `null` when a group has no eligible
+inputs.
+
+### Point-in-time statistics
+
+Like search, the query accepts a `pointInTime` to aggregate the world
+**as it existed at a past instant** — without standing up a derived
+counter entity that processors must maintain on every transition. Add it
+to the request body:
+
+```json
+{
+  "groupBy": ["state"],
+  "pointInTime": "2026-03-31T23:59:59Z"
+}
+```
+
+This answers end-of-quarter and audit roll-up questions directly — *how
+many claims were pending at midnight on the last day of Q1?* When
+omitted, the query runs against the current consistency time.
 
 ## Where to go next
 

--- a/src/content/docs/build/workflows-and-processors.mdx
+++ b/src/content/docs/build/workflows-and-processors.mdx
@@ -66,6 +66,38 @@ You can find the workflow schema in the [API reference](/reference/api/). See th
 
 An entity model can have multiple workflows, each with its own `criterion` at the workflow level. When an entity is created, the platform evaluates each active workflow's criterion to select the applicable workflow. The platform evaluates active workflows in the order they are defined and uses the first whose criterion matches (or the first with no criterion, which matches unconditionally). This allows different processing paths for different categories of entities within the same model.
 
+### Annotations
+
+Workflows, states, and transitions each accept an optional `annotations`
+object — arbitrary client-owned JSON metadata that the engine **stores
+and round-trips faithfully but never interprets**. Use it to attach
+concerns that belong to your application rather than the state machine:
+display labels and UI hints, permitted roles for application-level RBAC,
+or routing tags consumed by your own tooling.
+
+```json
+{
+  "version": "1.1",
+  "name": "Payment Request Workflow",
+  "initialState": "INVALID",
+  "active": true,
+  "annotations": {
+    "ui": { "color": "#0aa7c2", "icon": "payment" },
+    "rbac": { "editRoles": ["payments-admin"] }
+  },
+  "states": {
+    "INVALID": {
+      "annotations": { "label": "Needs validation" },
+      "transitions": []
+    }
+  }
+}
+```
+
+Each `annotations` value must be a JSON object and is capped at **64 KB**
+per field. The engine never reads these values; they are yours to
+produce and consume.
+
 ## Import and Export
 
 Workflows are managed via import and export API endpoints on the entity
@@ -78,6 +110,22 @@ existing workflows are reconciled with the payload:
 
 See [API reference](/reference/api/) for endpoint details and the full
 request/response schemas.
+
+### Strict validation
+
+From cyoda-go v0.8.1 the import endpoint validates payloads strictly and
+rejects the whole request rather than silently absorbing mistakes. A
+payload is rejected when it:
+
+- declares a schema `version` other than `"1.1"` (rejected with
+  `WORKFLOW_SCHEMA_VERSION_UNSUPPORTED`);
+- carries unknown or misspelled fields (e.g. `transtions`);
+- references a dangling state or reuses a name;
+- relies on an empty array to mean "leave unchanged" in `REPLACE` or
+  `ACTIVATE` mode — an empty array now deletes.
+
+Regenerate any import payloads authored against the older, lenient
+contract before upgrading.
 
 ## States
 

--- a/src/content/docs/concepts/authentication-and-identity.md
+++ b/src/content/docs/concepts/authentication-and-identity.md
@@ -46,25 +46,35 @@ downstream authorization.
 The result: the audit trail records who the original user was at every hop,
 and each service still only sees a token scoped to what it is allowed to do.
 
-## External key trust
+## External key trust and OIDC federation
 
-Cyoda can be configured to **trust tokens issued by an external IdP** — your
-corporate Okta, Auth0, or Keycloak, for example. The platform accepts tokens
-signed with keys it recognises, maps the external subject to an internal
-identity, and applies the local authorization rules. Users sign in with their
-organisation's single sign-on and receive entitlements within Cyoda.
+Cyoda can be configured to **trust tokens issued by external identity
+providers** — your corporate Okta, Auth0, Keycloak, Entra, or any
+spec-compliant OpenID Connect (OIDC) issuer. The platform validates tokens
+signed with keys it recognises, maps the external subject and roles onto an
+internal identity, and applies the local authorization rules. Users sign in
+with their organisation's single sign-on and receive entitlements within Cyoda.
 
-External key trust is configured per environment; the list of trusted signers
-and the subject-to-identity mapping are part of the tenant's identity
-configuration.
+Trust is established **per tenant**. cyoda-go keeps a registry of OIDC
+providers: each registration pins an issuer — and optionally the audiences it
+will accept and the claim that carries roles — and the platform validates an
+incoming token against the local issuer first, then against the registered
+providers in turn. Where several tenants share one physical IdP, tokens are
+disambiguated by audience and ambiguous tokens are rejected rather than
+guessed, so one tenant can never borrow another's trust.
+
+Provider metadata — the JWKS used to verify signatures — is fetched from each
+issuer's OIDC discovery document, refreshed across the cluster, and guarded
+against server-side request forgery.
 
 ## Where this is configured
 
-- **Self-hosted (cyoda-go).** Identity configuration — bootstrap credentials,
-  JWT signing keys, external IdP trust — is managed via cyoda-go
-  configuration. See the
-  [cyoda-go authentication reference](https://github.com/Cyoda/cyoda-go#authentication)
-  for the authoritative parameter list.
+- **Self-hosted (cyoda-go).** Identity is managed through cyoda-go's IAM
+  admin API and configuration: bootstrap credentials, JWT signing keys,
+  machine-to-machine clients, and OIDC provider trust. See
+  [Reference → Identity and IAM](/reference/identity-and-iam/) for the
+  endpoints and the configuration that governs them, or run `cyoda help auth`
+  against your binary.
 - **Cyoda Cloud.** Identity is surfaced as a managed service:
   [Cyoda Cloud → identity and entitlements](/cyoda-cloud/identity-and-entitlements/).
 

--- a/src/content/docs/cyoda-cloud/identity-and-entitlements.md
+++ b/src/content/docs/cyoda-cloud/identity-and-entitlements.md
@@ -13,9 +13,12 @@ live yet, and details may change as the design settles.
 :::
 
 > This page covers identity operations for the **hosted Cyoda Cloud**
-> platform. For self-hosted cyoda-go identity (OAuth 2.0 issuance,
-> M2M credentials, external key trust on your own instance), see the
-> [cyoda-go identity docs](https://github.com/Cyoda/cyoda-go/blob/main/docs/).
+> platform. The OIDC provider trust, signing-key, and M2M-client surface
+> described here as cloud design now ships in self-hosted **cyoda-go**;
+> for running it on your own instance see
+> [Reference → Identity and IAM](/reference/identity-and-iam/). The
+> data-plane contract is identical, so what you configure locally carries
+> over to the managed service.
 
 ## Overview
 

--- a/src/content/docs/reference/helm.mdx
+++ b/src/content/docs/reference/helm.mdx
@@ -51,6 +51,14 @@ never put raw credentials into the chart's `values.yaml` in a
 production deployment — wire an existing `Secret` via `existingSecret`
 or equivalent.
 
+## Database migrations
+
+Schema migrations can run under a **separate Postgres connection** from
+the runtime. Set an optional migration DSN (`migrate.postgres`) when the
+account that applies DDL should differ from the least-privilege account
+the running pods use — a common production split. When it is unset,
+migrations run over the runtime connection.
+
 ## Related topics
 
 <ul>

--- a/src/content/docs/reference/identity-and-iam.mdx
+++ b/src/content/docs/reference/identity-and-iam.mdx
@@ -1,0 +1,146 @@
+---
+title: "Identity and IAM"
+description: "Self-hosted cyoda-go IAM admin surface — OIDC provider trust, JWT signing keys, machine-to-machine clients, and the configuration that governs them."
+sidebar:
+  order: 35
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+cyoda-go is an OAuth 2.0 authorization server; this page is the operator's
+reference for the **IAM admin surface** that configures it on a
+self-hosted instance — which external identities to trust, which keys
+sign and verify tokens, and which machine-to-machine clients exist. For
+the conceptual model (token issuance, on-behalf-of exchange, federation),
+see [Authentication and identity](/concepts/authentication-and-identity/);
+for the managed equivalent, see
+[Cyoda Cloud → identity and entitlements](/cyoda-cloud/identity-and-entitlements/).
+
+All paths below are admin endpoints and require an administrative token.
+The [REST API reference](/reference/api/) carries the authoritative
+request/response schemas; this page covers what each group is for and how
+the pieces fit together. Run `cyoda help auth` against your binary for the
+version-specific detail.
+
+## OIDC provider trust
+
+Register the external OpenID Connect issuers a tenant should trust. Each
+registration is validated against its discovery document, and incoming
+tokens are checked against the local issuer first, then each registered
+provider in turn.
+
+| Method &amp; path | Purpose |
+| --- | --- |
+| `GET /oauth/oidc/providers` | List registered providers. |
+| `POST /oauth/oidc/providers` | Register a provider. |
+| `PATCH /oauth/oidc/providers/{id}` | Update a registration. |
+| `POST /oauth/oidc/providers/{id}/invalidate` | Stop trusting a provider (reversible). |
+| `POST /oauth/oidc/providers/{id}/reactivate` | Resume trusting it. |
+| `DELETE /oauth/oidc/providers/{id}` | Remove a registration. |
+| `POST /oauth/oidc/providers/reload` | Re-fetch provider metadata (JWKS) cluster-wide. |
+
+A registration describes how to trust the issuer:
+
+```json
+{
+  "wellKnownConfigUri": "https://your-idp/.well-known/openid-configuration",
+  "issuers": ["https://your-idp/"],
+  "expectedAudiences": ["cyoda-prod"],
+  "rolesClaim": "realm_access.roles"
+}
+```
+
+- **`wellKnownConfigUri`** (required) — the provider's OIDC discovery
+  endpoint. cyoda-go fetches the JWKS and metadata from it.
+- **`issuers`** — allowed `iss` values. When omitted, the `iss` claim must
+  match the discovery document's `issuer` exactly.
+- **`expectedAudiences`** — accepted `aud` values. **When several tenants
+  share one IdP, set a distinct audience per registration** — this is what
+  disambiguates tokens; ambiguous tokens are rejected rather than guessed.
+  When omitted, the audience is not checked and issuer binding is the only
+  trust anchor.
+- **`rolesClaim`** — the claim that carries roles, overriding the global
+  default (`CYODA_OIDC_ROLES_CLAIM`, typically `roles`). Per-provider
+  override accommodates IdP variation — Keycloak uses `realm_access.roles`,
+  Cognito uses `cognito:groups`. Object-nested claims are supported.
+
+<Aside type="note">
+OIDC registration requires a **UUID-formatted tenant**. Deployments that
+bootstrapped on the literal string `default-tenant` must migrate to a
+tenant UUID before registering a provider.
+</Aside>
+
+## JWT signing keys
+
+cyoda-go signs the tokens it issues with asymmetric keypairs and can also
+trust externally injected public keys. Both are managed under
+`/oauth/keys`.
+
+### Signing keypairs
+
+| Method &amp; path | Purpose |
+| --- | --- |
+| `GET /oauth/keys/keypair/current` | The active signing keypair (public part). |
+| `POST /oauth/keys/keypair` | Create / rotate a keypair. |
+| `POST /oauth/keys/keypair/{keyId}/invalidate` | Invalidate a keypair (with grace). |
+| `POST /oauth/keys/keypair/{keyId}/reactivate` | Reactivate it. |
+| `DELETE /oauth/keys/keypair/{keyId}` | Delete it. |
+
+### Trusted external keys
+
+The `/oauth/keys/trusted/*` endpoints register public keys from an
+external issuer so cyoda-go accepts tokens signed elsewhere. The same
+`invalidate` / `reactivate` / `delete` lifecycle applies.
+
+<Aside type="caution" title="Defaults changed in v0.8.1">
+
+- **Signing keys expire** after a default **365 days** and must be
+  rotated. The startup banner warns for the final 30 days before
+  expiry — wire rotation into your operations.
+- **Only `RS256`** is accepted for signing and verification. Other
+  algorithms are rejected at runtime.
+- **Trusted-key registration is off by default.** Opt in explicitly with
+  `CYODA_IAM_TRUSTED_KEY_REGISTRATION_ENABLED=true`.
+
+</Aside>
+
+## Machine-to-machine clients
+
+Manage the technical-user clients that authenticate with the OAuth 2.0
+client-credentials grant (see
+[machine-to-machine credentials](/concepts/authentication-and-identity/#machine-to-machine-credentials)).
+
+| Method &amp; path | Purpose |
+| --- | --- |
+| `GET /clients` | List M2M clients. |
+| `POST /clients` | Create a client. |
+| `PUT /clients/{clientId}/secret` | Rotate the client secret. |
+| `DELETE /clients/{clientId}` | Delete a client. |
+
+Creation returns the credential once, in
+[RFC 7591](https://www.rfc-editor.org/rfc/rfc7591) form — capture the
+secret at creation time:
+
+```json
+{
+  "client_id": "abc523BCD",
+  "client_secret": "…",
+  "client_id_issued_at": 1709913600,
+  "client_secret_expires_at": 0
+}
+```
+
+## Configuration
+
+The IAM behaviours above are governed by `CYODA_*` configuration; the
+authoritative key list lives in the binary (`cyoda help config`). The
+settings most likely to affect an upgrade:
+
+| Variable | Effect |
+| --- | --- |
+| `CYODA_IAM_TRUSTED_KEY_REGISTRATION_ENABLED` | Enables the trusted-key endpoints. Default `false`. |
+| `CYODA_OIDC_ROLES_CLAIM` | Default JWT claim read for roles when a provider sets no `rolesClaim`. |
+
+See [Configuration](/reference/configuration/) for the configuration
+model and [Authentication and identity](/concepts/authentication-and-identity/)
+for the concepts.


### PR DESCRIPTION
## Summary

The new-content half of the v0.8.1 docs work — documents the capabilities the release shipped, grounded in the actual OpenAPI spec (endpoint paths, request/response shapes, field names).

Replaces #96, which GitHub auto-closed when its stacked base branch was deleted on merge of #95. Branch has been rebased directly onto `main`; no functional change from #96.

## What's added

| Page | Change |
|---|---|
| `build/searching-entities.mdx` | New **Grouped statistics** section — `POST /entity/stats/{entityName}/{modelVersion}/query`, with `groupBy` / `aggregations` (`sum,avg,min,max,stdev`) / `condition` / `limit`, bucket response shape, and **point-in-time** aggregation. |
| `build/workflows-and-processors.mdx` | Client-owned **`annotations`** (≤64 KB, never interpreted) on workflows/states/transitions; **strict import validation**. |
| `concepts/authentication-and-identity.md` | Expanded external key trust into **per-tenant OIDC federation**. |
| `reference/identity-and-iam.mdx` | **New page** — self-hosted IAM admin surface (OIDC providers, signing keypairs, trusted keys, M2M clients) + v0.8.1 default changes. |
| `cyoda-cloud/identity-and-entitlements.md` | Note the surface now ships in self-hosted cyoda-go; link the new page. |
| `reference/helm.mdx` | Note the optional separate migration DSN (`migrate.postgres`). |

## Verification

`npm run build:only` — clean, 272 pages; `/reference/identity-and-iam/` renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)