### PR TITLE
docs(schemas): rename "JSON Schemas" section to "CloudEvents Schemas"

### DIFF
--- a/scripts/generate-schema-pages.js
+++ b/scripts/generate-schema-pages.js
@@ -216,13 +216,13 @@ own code.
     : '';
 
   const mainIndexContent = `---
-title: JSON Schemas
-description: Complete reference for all JSON schemas used in Cyoda
+title: CloudEvents Schemas
+description: Complete reference for the CloudEvent and entity/model JSON schemas used in Cyoda
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
 
-# JSON Schemas
+# CloudEvents Schemas
 
 This section documents the JSON schemas used by the Cyoda platform — CloudEvent
 payloads exchanged over the gRPC processing stream, plus the entity and model

--- a/src/content/docs/reference/index.mdx
+++ b/src/content/docs/reference/index.mdx
@@ -26,7 +26,7 @@ is the authoritative source.
 
 - **[API](./api/)** — REST OpenAPI 3.1 reference, interactive viewer.
 - **[gRPC](./api/#grpc)** — gRPC CloudEventsService (cross-linked from the API page).
-- **[JSON Schemas](./schemas/)** — CloudEvent payload schemas, extracted from the
+- **[CloudEvents Schemas](./schemas/)** — CloudEvent payload schemas, extracted from the
   pinned binary at build time.
 - **[Trino SQL](./trino/)** — SQL analytics surface (Cyoda Cloud; upcoming).
 


### PR DESCRIPTION
## Summary

The `reference/schemas/` viewer documents the **CloudEvent and entity/model schema bundle** extracted from `cyoda help cloudevents json` — it is *not* the OpenAPI request/response schemas (those are rendered in the [API reference](/reference/api/)). The generic name "JSON Schemas" invited confusion with the OpenAPI surface.

Renames the section title, page heading, and the reference-index link label to **"CloudEvents Schemas"**.

- `scripts/generate-schema-pages.js` — root index `title` + H1 (the title drives both the page heading and the sidebar menu item).
- `reference/index.mdx` — matching link label.

No content or URL changes; the generated schema pages remain git-ignored and regenerate on build.

## Verification

`npm run build:only` — clean, 272 pages; page title and sidebar item render as "CloudEvents Schemas".

🤖 Generated with [Claude Code](https://claude.com/claude-code)